### PR TITLE
Adding volatile attribute to thread_comm in mydata structure - some c…

### DIFF
--- a/source_files/firestarter_global.h
+++ b/source_files/firestarter_global.h
@@ -86,7 +86,7 @@ typedef struct mydata
 {                                   
    struct threaddata *threaddata;           
    cpu_info_t *cpuinfo;
-   int *thread_comm;
+   volatile int *thread_comm;
    volatile unsigned int ack;   
    unsigned int num_threads;
 } mydata_t;


### PR DESCRIPTION
Added volatile attribute to thread_comm in mydata structure - some compilers generate code caching non-volatile dereferenced pointer values causing non-deterministic init time