### PR TITLE
automatic precision switching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,134 @@
 language: generic
 
-sudo: required
 dist: trusty
+sudo: required
 
 matrix:
   include:
     - os: linux
-      env: LINUX_CC="gcc-7"
-      compiler: gcc
-      addons:
-        apt:
-          packages:
-            - gcc-7
-            - g++-7
-            - nvidia-cuda-dev
-          sources: &sources
-            - ubuntu-toolchain-r-test
-    - os: linux
-      env: LINUX_CC="gcc-6"
+      env: 
+        - LINUX_CC="gcc-6"
+        - CUDA=6.5-14
       compiler: gcc
       addons:
         apt:
           packages:
             - gcc-6
             - g++-6
-            - nvidia-cuda-dev
+          sources: &sources
+            - ubuntu-toolchain-r-test
+    - os: linux
+      env: 
+        - LINUX_CC="gcc-6"
+        - CUDA=7.0-28
+      compiler: gcc
+      addons:
+        apt:
+          packages:
+            - gcc-6
+            - g++-6
+          sources: &sources
+            - ubuntu-toolchain-r-test
+    - os: linux
+      env: 
+        - LINUX_CC="gcc-6"
+        - CUDA=7.5-18
+      compiler: gcc
+      addons:
+        apt:
+          packages:
+            - gcc-6
+            - g++-6
+          sources: &sources
+            - ubuntu-toolchain-r-test
+    - os: linux
+      env: 
+        - LINUX_CC="gcc-6"
+        - CUDA=8.0.61-1
+      compiler: gcc
+      addons:
+        apt:
+          packages:
+            - gcc-6
+            - g++-6
+          sources: &sources
+            - ubuntu-toolchain-r-test
+    - os: linux
+      env: 
+        - LINUX_CC="gcc-6"
+        - CUDA=10.0.130-1
+      compiler: gcc
+      addons:
+        apt:
+          packages:
+            - gcc-6
+            - g++-6
           sources: *sources
+    - os: linux
+      env: 
+        - LINUX_CC="gcc-7"
+        - CUDA=6.5-14
+      compiler: gcc
+      addons:
+        apt:
+          packages:
+            - gcc-7
+            - g++-7
+          sources: *sources
+    - os: linux
+      env: 
+        - LINUX_CC="gcc-7"
+        - CUDA=7.0-28
+      compiler: gcc
+      addons:
+        apt:
+          packages:
+            - gcc-7
+            - g++-7
+          sources: *sources
+    - os: linux
+      env: 
+        - LINUX_CC="gcc-7"
+        - CUDA=7.5-18
+      compiler: gcc
+      addons:
+        apt:
+          packages:
+            - gcc-7
+            - g++-7
+          sources: *sources
+    - os: linux
+      env: 
+        - LINUX_CC="gcc-7"
+        - CUDA=8.0.61-1
+      compiler: gcc
+      addons:
+        apt:
+          packages:
+            - gcc-7
+            - g++-7
+          sources: *sources
+    - os: linux
+      env: 
+        - LINUX_CC="gcc-7"
+        - CUDA=10.0.130-1
+      compiler: gcc
+      addons:
+        apt:
+          packages:
+            - gcc-7
+            - g++-7
+          sources: *sources
+
+
+before_install:
+  - source travis-ci/install-cuda-trusty.sh
+  - nvcc --version
+
 before_script:
   - mkdir -p build
   - cd build
   - ../code-generator.py --enable-cuda
+
 script:
-  - make all
+- make all

--- a/source_files/README
+++ b/source_files/README
@@ -83,7 +83,8 @@ Options:
 $CUDA
 $CUDA CUDA Options:
 $CUDA -g         | --gpus             number of gpus to use (default: all)
-$CUDA -f         | --usegpufloat      use single precision matrix multiplications instead of double
+$CUDA -f         | --usegpufloat      use single precision matrix multiplications (default: depends on GPU) 
+$CUDA -d         | --usegpudouble     use double precision matrix multiplications (default: depends on GPU)
 $CUDA -m         | --matrixsize       size of the Matrix to calculate (default: 12288)
 
 Examples:

--- a/source_files/gpu.c
+++ b/source_files/gpu.c
@@ -275,9 +275,8 @@ static int get_msize(int device_index) {
 
 void* init_gpu(void * gpu) {
     gpuvar = (gpustruct_t*)gpu;
-    int max_msize_single = 0;
-    int max_msize_double = 0;
-
+    int max_msize = 0;
+    
     if(gpuvar->use_device) {
         CUDA_SAFE_CALL(cuInit(0), -1);
         int devCount;

--- a/source_files/gpu.c
+++ b/source_files/gpu.c
@@ -107,17 +107,6 @@ static void* fillup(int useD, int size) {
     }
 }
 
-#if ( CUDART_VERSION < 8000 )
-//as precision ratio is not supported return default/user input value  
-static int get_precision() {
-    if(gpuvar->use_double) {
-        return 1;
-    } else {
-        return 0;
-    }
-}
-#endif
-
 #if ( CUDART_VERSION >= 8000 )  
 //read precision ratio (dp/sp) of GPU to choose the right variant for maximum workload
 static int get_precision(struct cudaDeviceProp properties) {

--- a/source_files/gpu.c
+++ b/source_files/gpu.c
@@ -120,7 +120,7 @@ static int get_precision(struct cudaDeviceProp properties) {
 }
 #else
 //as precision ratio is not supported return default/user input value  
-static int get_precision() {
+static int get_precision(struct cudaDeviceProp properties) {
     if(gpuvar->use_double) {
         return 1;
     } else {

--- a/source_files/gpu.c
+++ b/source_files/gpu.c
@@ -111,8 +111,7 @@ static void* fillup(int useD, int size) {
 }
 
 //read precision ratio (dp/sp) of GPU to choose the right version for maximum workload
-static int get_precision(struct cudaDeviceProp properties) {
-    int precision_ratio = properties.singleToDoublePrecisionPerfRatio;
+static int get_precision(int precision_ratio) {
     if(gpuvar->use_double == 2 && precision_ratio > 3){
         return 0;
     } else if(gpuvar->use_double) {
@@ -146,7 +145,7 @@ static void* create_load(void * index) {
     CUDA_SAFE_CALL(cublasCreate(&cublas), device_index);
     CUDA_SAFE_CALL(cudaGetDeviceProperties(&properties, device_index), device_index);
 
-    pthread_use_double = get_precision(properties);
+    pthread_use_double = get_precision(properties.singleToDoublePrecisionPerfRatio);
 
     pthread_mutex_lock(&wait_for_init_mutex);
     if(pthread_use_double) {
@@ -285,7 +284,7 @@ static int get_msize(int device_index) {
     CUDA_SAFE_CALL(cuMemGetInfo(&memory_avail,&memory_total), device_index);
     CUDA_SAFE_CALL(cudaGetDeviceProperties(&properties, device_index), device_index);
 
-    use_double = get_precision(properties);
+    use_double = get_precision(properties.singleToDoublePrecisionPerfRatio);
 
     CUDA_SAFE_CALL(cuCtxDestroy(context), device_index);
 

--- a/source_files/main.c
+++ b/source_files/main.c
@@ -458,7 +458,7 @@ int main(int argc, char *argv[])
 
 $CUDA     #ifdef CUDA
 $CUDA     gpustruct_t * structpointer=malloc(sizeof(gpustruct_t));
-$CUDA     structpointer->use_double=1;     //we want to use Doubles, if no -f Argument is given
+$CUDA     structpointer->use_double=2;     //default: double; float if GPU's singleToDoublePrecisionPerfRatio is too big
 $CUDA     structpointer->msize=0;
 $CUDA     structpointer->use_device=-1;    //by default, we use all GPUs with -1 option.
 $CUDA     structpointer->verbose=1;       //Verbosity
@@ -476,9 +476,10 @@ $CUDA
         {"avail",       no_argument,        0, 'a'},
         {"function",    required_argument,  0, 'i'},
 $CUDA         #ifdef CUDA
-$CUDA         {"usegpufloat", no_argument,        0, 'f'},
-$CUDA         {"gpus",        required_argument,  0, 'g'},
-$CUDA         {"matrixsize",  required_argument,  0, 'm'},
+$CUDA         {"usegpufloat",  no_argument,        0, 'f'},
+$CUDA         {"usegpudouble", no_argument,        0, 'd'},
+$CUDA         {"gpus",         required_argument,  0, 'g'},
+$CUDA         {"matrixsize",   required_argument,  0, 'm'},
 $CUDA         #endif
         {"threads",     required_argument,  0, 'n'},
         #if (defined(linux) || defined(__linux__)) && defined (AFFINITY)
@@ -545,7 +546,18 @@ $CUDA             #endif
             break;
         #endif
 $CUDA         #ifdef CUDA
+$CUDA         case 'd':
+$CUDA             if(structpointer->use_double == 0){
+$CUDA               printf("Error: -f and -d cannot be used together\n");
+$CUDA               return EXIT_FAILURE;
+$CUDA             }
+$CUDA             structpointer->use_double=1; //enabling double-precision
+$CUDA             break;
 $CUDA         case 'f':
+$CUDA             if(structpointer->use_double == 1){
+$CUDA               printf("Error: -f and -d cannot be used together\n");
+$CUDA               return EXIT_FAILURE;
+$CUDA             }  
 $CUDA             structpointer->use_double=0; //disabling double-precision
 $CUDA             break;
 $CUDA         case 'm':

--- a/templates/main_c.py
+++ b/templates/main_c.py
@@ -117,7 +117,7 @@ def main_getopt(file,version):
     opts_noarg="chvwqar"
     opts_arg="i:t:l:p:n:"
     if version.enable_cuda == 1:
-        opts_noarg=opts_noarg+"f"
+        opts_noarg=opts_noarg+"df"
         opts_arg=opts_arg+"m:g:"
     file.write("        #if (defined(linux) || defined(__linux__)) && defined (AFFINITY)\n")
     file.write("        c = getopt_long(argc, argv, \""+opts_noarg+"b:"+opts_arg+"\", long_options, NULL);\n")

--- a/travis-ci/install-cuda-trusty.sh
+++ b/travis-ci/install-cuda-trusty.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+travis_retry wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1404/x86_64/cuda-repo-ubuntu1404_${CUDA}_amd64.deb
+travis_retry sudo apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/7fa2af80.pub
+travis_retry sudo dpkg -i cuda-repo-ubuntu1404_${CUDA}_amd64.deb
+travis_retry sudo apt-get update -qq
+
+export CUDA_VERSION=$(expr ${CUDA} : '\([0-9]*\.[0-9]*\)')
+export CUDA_VERSION_APT=${CUDA_VERSION/./-}
+
+travis_retry sudo apt-get install -y cuda-drivers cuda-core-${CUDA_VERSION_APT} cuda-cudart-dev-${CUDA_VERSION_APT} cuda-cublas-dev-${CUDA_VERSION_APT}
+travis_retry sudo apt-get clean
+
+export CUDA_ROOT=/usr/local/cuda-${CUDA_VERSION}
+export LD_LIBRARY_PATH=${CUDA_HOME}/nvvm/lib64:${LD_LIBRARY_PATH}
+export LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${LD_LIBRARY_PATH}
+export PATH=${CUDA_ROOT}/bin:${PATH}
+
+sudo mkdir -p /opt/cuda/
+sudo ln -s /usr/local/cuda-${CUDA_VERSION}/include /opt/cuda/
+sudo ln -s /usr/local/cuda-${CUDA_VERSION}/lib64 /opt/cuda/lib64
+sudo ln -s /usr/local/cuda-${CUDA_VERSION}/lib64 /opt/cuda/lib


### PR DESCRIPTION
FIRESTARTER_CUDA uses single precision for maximum workload as default if a GPU have bad single to double precision ratio; new option '-d' to enforce double precision; new GPU output with  information about the precision