### PR TITLE
Error detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ General Options:
   -b, --bind CPULIST            Select certain CPUs. CPULIST format: "x,y,z",
                                 "x-y", "x-y/step", and any combination of the
                                 above. Cannot be combined with -n | --threads.
+      --error-detection         Enable error detection. This aborts execution when the
+                                calculated data is corruped by errors. FIRESTARTER must run
+                                with 2 or more threads for this feature. Cannot be used with
+                                -l | --load and --optimize.
 
 Specialized workloads:
       --list-instruction-groups

--- a/derivation.nix
+++ b/derivation.nix
@@ -1,4 +1,5 @@
 { stdenv
+, lib
 , cmake
 , glibc_multi
 , glibc
@@ -44,7 +45,6 @@ let
   };
 
 in
-with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "firestarter";
   version = "0.0";
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
     "-DFIRESTARTER_BUILD_HWLOC=OFF"
     "-DCMAKE_C_COMPILER_WORKS=1"
     "-DCMAKE_CXX_COMPILER_WORKS=1"
-  ] ++ optionals withCuda [
+  ] ++ lib.optionals withCuda [
    "-DFIRESTARTER_BUILD_TYPE=FIRESTARTER_CUDA"
   ];
 
@@ -69,7 +69,7 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/bin
-    cp src/FIRESTARTER${optionalString withCuda ''_CUDA''} $out/bin/
+    cp src/FIRESTARTER${lib.optionalString withCuda ''_CUDA''} $out/bin/
   '';
 
 }

--- a/include/firestarter/DumpRegisterStruct.hpp
+++ b/include/firestarter/DumpRegisterStruct.hpp
@@ -21,42 +21,22 @@
 
 #pragma once
 
-#include <firestarter/DumpRegisterStruct.hpp>
-#include <firestarter/LoadWorkerData.hpp>
-
-#include <chrono>
-
-#ifdef FIRESTARTER_DEBUG_FEATURES
-
 namespace firestarter {
 
-class DumpRegisterWorkerData {
-public:
-  DumpRegisterWorkerData(std::shared_ptr<LoadWorkerData> loadWorkerData,
-                         std::chrono::seconds dumpTimeDelta,
-                         std::string dumpFilePath)
-      : loadWorkerData(loadWorkerData), dumpTimeDelta(dumpTimeDelta) {
+/* DO NOT CHANGE! the asm load-loop tests if it should dump the current register
+ * content */
+enum DumpVariable : unsigned long long { Start = 0, Wait = 1 };
 
-    if (dumpFilePath.empty()) {
-      char cwd[PATH_MAX];
-      if (getcwd(cwd, sizeof(cwd)) != NULL) {
-        this->dumpFilePath = cwd;
-      } else {
-        log::error() << "getcwd() failed. Set --dump-registers-outpath to /tmp";
-        this->dumpFilePath = "/tmp";
-      }
-    } else {
-      this->dumpFilePath = dumpFilePath;
-    }
-  }
+#define REGISTER_MAX_NUM 32
 
-  ~DumpRegisterWorkerData() {}
-
-  std::shared_ptr<LoadWorkerData> loadWorkerData;
-  const std::chrono::seconds dumpTimeDelta;
-  std::string dumpFilePath;
+struct DumpRegisterStruct {
+  // REGISTER_MAX_NUM cachelines
+  volatile double registerValues[REGISTER_MAX_NUM * 8];
+  // pad to use a whole cacheline
+  volatile unsigned long long padding[7];
+  volatile DumpVariable dumpVar;
 };
 
-} // namespace firestarter
+#undef REGISTER_MAX_NUM
 
-#endif
+} // namespace firestarter

--- a/include/firestarter/Environment/Payload/Payload.hpp
+++ b/include/firestarter/Environment/Payload/Payload.hpp
@@ -97,7 +97,8 @@ public:
       std::vector<std::pair<std::string, unsigned>> const &proportion,
       unsigned instructionCacheSize,
       std::list<unsigned> const &dataCacheBufferSize, unsigned ramBufferSize,
-      unsigned thread, unsigned numberOfLines, bool dumpRegisters) = 0;
+      unsigned thread, unsigned numberOfLines, bool dumpRegisters,
+      bool errorDetection) = 0;
   virtual std::list<std::string> getAvailableInstructions() const = 0;
   virtual void init(unsigned long long *memoryAddr,
                     unsigned long long bufferSize) = 0;

--- a/include/firestarter/Environment/X86/Payload/AVX512Payload.hpp
+++ b/include/firestarter/Environment/X86/Payload/AVX512Payload.hpp
@@ -34,7 +34,8 @@ public:
       std::vector<std::pair<std::string, unsigned>> const &proportion,
       unsigned instructionCacheSize,
       std::list<unsigned> const &dataCacheBufferSize, unsigned ramBufferSize,
-      unsigned thread, unsigned numberOfLines, bool dumpRegisters) override;
+      unsigned thread, unsigned numberOfLines, bool dumpRegisters,
+      bool errorDetection) override;
   std::list<std::string> getAvailableInstructions() const override;
   void init(unsigned long long *memoryAddr,
             unsigned long long bufferSize) override;

--- a/include/firestarter/Environment/X86/Payload/AVXPayload.hpp
+++ b/include/firestarter/Environment/X86/Payload/AVXPayload.hpp
@@ -34,7 +34,8 @@ public:
       std::vector<std::pair<std::string, unsigned>> const &proportion,
       unsigned instructionCacheSize,
       std::list<unsigned> const &dataCacheBufferSize, unsigned ramBufferSize,
-      unsigned thread, unsigned numberOfLines, bool dumpRegisters) override;
+      unsigned thread, unsigned numberOfLines, bool dumpRegisters,
+      bool errorDetection) override;
   std::list<std::string> getAvailableInstructions() const override;
   void init(unsigned long long *memoryAddr,
             unsigned long long bufferSize) override;

--- a/include/firestarter/Environment/X86/Payload/FMA4Payload.hpp
+++ b/include/firestarter/Environment/X86/Payload/FMA4Payload.hpp
@@ -37,7 +37,8 @@ public:
       std::vector<std::pair<std::string, unsigned>> const &proportion,
       unsigned instructionCacheSize,
       std::list<unsigned> const &dataCacheBufferSize, unsigned ramBufferSize,
-      unsigned thread, unsigned numberOfLines, bool dumpRegisters) override;
+      unsigned thread, unsigned numberOfLines, bool dumpRegisters,
+      bool errorDetection) override;
   std::list<std::string> getAvailableInstructions() const override;
   void init(unsigned long long *memoryAddr,
             unsigned long long bufferSize) override;

--- a/include/firestarter/Environment/X86/Payload/FMAPayload.hpp
+++ b/include/firestarter/Environment/X86/Payload/FMAPayload.hpp
@@ -35,7 +35,8 @@ public:
       std::vector<std::pair<std::string, unsigned>> const &proportion,
       unsigned instructionCacheSize,
       std::list<unsigned> const &dataCacheBufferSize, unsigned ramBufferSize,
-      unsigned thread, unsigned numberOfLines, bool dumpRegisters) override;
+      unsigned thread, unsigned numberOfLines, bool dumpRegisters,
+      bool errorDetection) override;
   std::list<std::string> getAvailableInstructions() const override;
   void init(unsigned long long *memoryAddr,
             unsigned long long bufferSize) override;

--- a/include/firestarter/Environment/X86/Payload/SSE2Payload.hpp
+++ b/include/firestarter/Environment/X86/Payload/SSE2Payload.hpp
@@ -34,7 +34,8 @@ public:
       std::vector<std::pair<std::string, unsigned>> const &proportion,
       unsigned instructionCacheSize,
       std::list<unsigned> const &dataCacheBufferSize, unsigned ramBufferSize,
-      unsigned thread, unsigned numberOfLines, bool dumpRegisters) override;
+      unsigned thread, unsigned numberOfLines, bool dumpRegisters,
+      bool errorDetection) override;
   std::list<std::string> getAvailableInstructions() const override;
   void init(unsigned long long *memoryAddr,
             unsigned long long bufferSize) override;

--- a/include/firestarter/Environment/X86/Payload/X86Payload.hpp
+++ b/include/firestarter/Environment/X86/Payload/X86Payload.hpp
@@ -55,7 +55,7 @@ protected:
   template <typename Vec>
   void
   emitErrorDetectionCode(asmjit::x86::Builder &cb, asmjit::x86::Mm iter_reg,
-                         asmjit::x86::Gp temp_reg, asmjit::x86::Gp temp_reg2);
+                         asmjit::x86::Gpq temp_reg, asmjit::x86::Gpq temp_reg2);
 
 public:
   X86Payload(asmjit::x86::Features const &supportedFeatures,

--- a/include/firestarter/Environment/X86/Payload/X86Payload.hpp
+++ b/include/firestarter/Environment/X86/Payload/X86Payload.hpp
@@ -52,10 +52,10 @@ protected:
     return this->_supportedFeatures;
   }
 
-  template <typename Vec>
-  void
-  emitErrorDetectionCode(asmjit::x86::Builder &cb, asmjit::x86::Mm iter_reg,
-                         asmjit::x86::Gpq temp_reg, asmjit::x86::Gpq temp_reg2);
+  template <class IterReg, class VectorReg>
+  void emitErrorDetectionCode(asmjit::x86::Builder &cb, IterReg iter_reg,
+                              asmjit::x86::Gpq temp_reg,
+                              asmjit::x86::Gpq temp_reg2);
 
 public:
   X86Payload(asmjit::x86::Features const &supportedFeatures,

--- a/include/firestarter/Environment/X86/Payload/X86Payload.hpp
+++ b/include/firestarter/Environment/X86/Payload/X86Payload.hpp
@@ -54,6 +54,7 @@ protected:
 
   template <class IterReg, class VectorReg>
   void emitErrorDetectionCode(asmjit::x86::Builder &cb, IterReg iter_reg,
+                              asmjit::x86::Gpq pointer_reg,
                               asmjit::x86::Gpq temp_reg,
                               asmjit::x86::Gpq temp_reg2);
 

--- a/include/firestarter/Environment/X86/Payload/X86Payload.hpp
+++ b/include/firestarter/Environment/X86/Payload/X86Payload.hpp
@@ -52,6 +52,11 @@ protected:
     return this->_supportedFeatures;
   }
 
+  template <typename Vec>
+  void
+  emitErrorDetectionCode(asmjit::x86::Builder &cb, asmjit::x86::Mm iter_reg,
+                         asmjit::x86::Gp temp_reg, asmjit::x86::Gp temp_reg2);
+
 public:
   X86Payload(asmjit::x86::Features const &supportedFeatures,
              std::initializer_list<asmjit::x86::Features::Id> featureRequests,

--- a/include/firestarter/Environment/X86/Payload/X86Payload.hpp
+++ b/include/firestarter/Environment/X86/Payload/X86Payload.hpp
@@ -54,6 +54,7 @@ protected:
 
   template <class IterReg, class VectorReg>
   void emitErrorDetectionCode(asmjit::x86::Builder &cb, IterReg iter_reg,
+                              asmjit::x86::Gpq addrHigh_reg,
                               asmjit::x86::Gpq pointer_reg,
                               asmjit::x86::Gpq temp_reg,
                               asmjit::x86::Gpq temp_reg2);

--- a/include/firestarter/Environment/X86/Payload/ZENFMAPayload.hpp
+++ b/include/firestarter/Environment/X86/Payload/ZENFMAPayload.hpp
@@ -36,7 +36,8 @@ public:
       std::vector<std::pair<std::string, unsigned>> const &proportion,
       unsigned instructionCacheSize,
       std::list<unsigned> const &dataCacheBufferSize, unsigned ramBufferSize,
-      unsigned thread, unsigned numberOfLines, bool dumpRegisters) override;
+      unsigned thread, unsigned numberOfLines, bool dumpRegisters,
+      bool errorDetection) override;
   std::list<std::string> getAvailableInstructions() const override;
   void init(unsigned long long *memoryAddr,
             unsigned long long bufferSize) override;

--- a/include/firestarter/ErrorDetectionStruct.hpp
+++ b/include/firestarter/ErrorDetectionStruct.hpp
@@ -1,0 +1,46 @@
+/******************************************************************************
+ * FIRESTARTER - A Processor Stress Test Utility
+ * Copyright (C) 2021 TU Dresden, Center for Information Services and High
+ * Performance Computing
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/\>.
+ *
+ * Contact: daniel.hackenberg@tu-dresden.de
+ *****************************************************************************/
+
+#pragma once
+
+namespace firestarter {
+
+struct ErrorDetectionStruct {
+  // we have two cache lines (64B) containing each two 16B local variable and
+  // one ptr (8B)
+
+  // the pointer to 16B of communication
+  volatile unsigned long long *communicationLeft;
+  volatile unsigned long long localsLeft[4];
+  // if this variable is not 0, an error occured in the comparison with the left
+  // thread.
+  volatile unsigned long long errorLeft;
+  volatile unsigned long long paddingLeft[2];
+
+  volatile unsigned long long *communicationRight;
+  volatile unsigned long long localsRight[4];
+  // if this variable is not 0, an error occured in the comparison with the
+  // right thread.
+  volatile unsigned long long errorRight;
+  volatile unsigned long long paddingRight[2];
+};
+
+} // namespace firestarter

--- a/include/firestarter/Firestarter.hpp
+++ b/include/firestarter/Firestarter.hpp
@@ -147,6 +147,7 @@ private:
   // LoadThreadWorker.cpp
   int initLoadWorkers(bool lowLoad, unsigned long long period);
   void joinLoadWorkers();
+  void printThreadErrorReport();
   void printPerformanceReport();
 
   void signalWork() { signalLoadWorkers(THREAD_WORK); };
@@ -194,6 +195,8 @@ private:
 #ifndef FIRESTARTER_BUILD_CUDA_ONLY
   std::vector<std::pair<std::thread, std::shared_ptr<LoadWorkerData>>>
       loadThreads;
+
+  std::vector<std::shared_ptr<unsigned long long>> errorCommunication;
 
 #ifdef FIRESTARTER_DEBUG_FEATURES
   std::thread dumpRegisterWorkerThread;

--- a/include/firestarter/Firestarter.hpp
+++ b/include/firestarter/Firestarter.hpp
@@ -71,9 +71,9 @@ public:
               unsigned lineCount, bool allowUnavailablePayload,
               bool dumpRegisters,
               std::chrono::seconds const &dumpRegistersTimeDelta,
-              std::string const &dumpRegistersOutpath, int gpus,
-              unsigned gpuMatrixSize, bool gpuUseFloat, bool gpuUseDouble,
-              bool listMetrics, bool measurement,
+              std::string const &dumpRegistersOutpath, bool errorDetection,
+              int gpus, unsigned gpuMatrixSize, bool gpuUseFloat,
+              bool gpuUseDouble, bool listMetrics, bool measurement,
               std::chrono::milliseconds const &startDelta,
               std::chrono::milliseconds const &stopDelta,
               std::chrono::milliseconds const &measurementInterval,
@@ -100,6 +100,7 @@ private:
   const bool _dumpRegisters;
   const std::chrono::seconds _dumpRegistersTimeDelta;
   const std::string _dumpRegistersOutpath;
+  const bool _errorDetection;
   const int _gpus;
   const unsigned _gpuMatrixSize;
   const bool _gpuUseFloat;
@@ -144,8 +145,7 @@ private:
 #endif
 
   // LoadThreadWorker.cpp
-  int initLoadWorkers(bool lowLoad, unsigned long long period,
-                      bool dumpRegisters);
+  int initLoadWorkers(bool lowLoad, unsigned long long period);
   void joinLoadWorkers();
   void printPerformanceReport();
 

--- a/include/firestarter/LoadWorkerData.hpp
+++ b/include/firestarter/LoadWorkerData.hpp
@@ -22,10 +22,32 @@
 #pragma once
 
 #include <firestarter/Constants.hpp>
+#include <firestarter/DumpRegisterStruct.hpp>
 #include <firestarter/Environment/Environment.hpp>
+#include <firestarter/ErrorDetectionStruct.hpp>
 
 #include <atomic>
+#include <memory>
 #include <mutex>
+
+#define PAD_SIZE(size, align)                                                  \
+  align *(int)std::ceil((double)size / (double)align)
+
+#if defined(__APPLE__)
+#define ALIGNED_MALLOC(size, align) aligned_alloc(align, PAD_SIZE(size, align))
+#define ALIGNED_FREE free
+#elif defined(__MINGW64__)
+#define ALIGNED_MALLOC(size, align) _mm_malloc(PAD_SIZE(size, align), align)
+#define ALIGNED_FREE _mm_free
+#elif defined(_MSC_VER)
+#define ALIGNED_MALLOC(size, align)                                            \
+  _aligned_malloc(PAD_SIZE(size, align), align)
+#define ALIGNED_FREE _aligned_free
+#else
+#define ALIGNED_MALLOC(size, align)                                            \
+  std::aligned_alloc(align, PAD_SIZE(size, align))
+#define ALIGNED_FREE std::free
+#endif
 
 namespace firestarter {
 
@@ -38,18 +60,47 @@ public:
       : addrHigh(loadVar), period(period), dumpRegisters(dumpRegisters),
         errorDetection(errorDetection), _id(id), _environment(environment),
         _config(new environment::platform::RuntimeConfig(
-            environment.selectedConfig())) {}
+            environment.selectedConfig())) {
+    // use REGISTER_MAX_NUM cache lines for the dumped registers
+    // and another cache line for the control variable.
+    // as we are doing aligned moves we only have the option to waste a whole
+    // cacheline
+    addrOffset = dumpRegisters
+                     ? sizeof(DumpRegisterStruct) / sizeof(unsigned long long)
+                     : 0;
 
-  ~LoadWorkerData() { delete _config; }
+    addrOffset += errorDetection ? sizeof(ErrorDetectionStruct) /
+                                       sizeof(unsigned long long)
+                                 : 0;
+  }
+
+  ~LoadWorkerData() {
+    delete _config;
+    if (addrMem - addrOffset != nullptr) {
+      ALIGNED_FREE(addrMem - addrOffset);
+    }
+  }
+
+  void setErrorCommunication(
+      std::shared_ptr<unsigned long long> communicationLeft,
+      std::shared_ptr<unsigned long long> communicationRight) {
+    this->communicationLeft = communicationLeft;
+    this->communicationRight = communicationRight;
+  }
 
   int id() const { return _id; }
   environment::Environment &environment() const { return _environment; }
   environment::platform::RuntimeConfig &config() const { return *_config; }
 
+  const ErrorDetectionStruct *errorDetectionStruct() const {
+    return reinterpret_cast<ErrorDetectionStruct *>(addrMem - addrOffset);
+  }
+
   int comm = THREAD_WAIT;
   bool ack = false;
   std::mutex mutex;
-  unsigned long long *addrMem;
+  unsigned long long *addrMem = nullptr;
+  unsigned long long addrOffset;
   volatile unsigned long long *addrHigh;
   unsigned long long buffersizeMem;
   unsigned long long iterations = 0;
@@ -65,6 +116,8 @@ public:
   unsigned long long period;
   bool dumpRegisters;
   bool errorDetection;
+  std::shared_ptr<unsigned long long> communicationLeft;
+  std::shared_ptr<unsigned long long> communicationRight;
 
 private:
   int _id;

--- a/include/firestarter/LoadWorkerData.hpp
+++ b/include/firestarter/LoadWorkerData.hpp
@@ -33,9 +33,10 @@ class LoadWorkerData {
 public:
   LoadWorkerData(int id, environment::Environment &environment,
                  volatile unsigned long long *loadVar,
-                 unsigned long long period, bool dumpRegisters)
+                 unsigned long long period, bool dumpRegisters,
+                 bool errorDetection)
       : addrHigh(loadVar), period(period), dumpRegisters(dumpRegisters),
-        _id(id), _environment(environment),
+        errorDetection(errorDetection), _id(id), _environment(environment),
         _config(new environment::platform::RuntimeConfig(
             environment.selectedConfig())) {}
 
@@ -63,6 +64,7 @@ public:
   // used in low load routine to sleep 1/100th of this time
   unsigned long long period;
   bool dumpRegisters;
+  bool errorDetection;
 
 private:
   int _id;

--- a/src/firestarter/Environment/X86/Payload/AVX512Payload.cpp
+++ b/src/firestarter/Environment/X86/Payload/AVX512Payload.cpp
@@ -384,7 +384,7 @@ int AVX512Payload::compilePayload(
   }
 
   if (errorDetection) {
-    this->emitErrorDetectionCode<decltype(iter_reg), Ymm>(
+    this->emitErrorDetectionCode<decltype(iter_reg), Zmm>(
         cb, iter_reg, addrHigh_reg, pointer_reg, temp_reg, temp_reg2);
   }
 

--- a/src/firestarter/Environment/X86/Payload/AVX512Payload.cpp
+++ b/src/firestarter/Environment/X86/Payload/AVX512Payload.cpp
@@ -29,7 +29,8 @@ int AVX512Payload::compilePayload(
     std::vector<std::pair<std::string, unsigned>> const &proportion,
     unsigned instructionCacheSize,
     std::list<unsigned> const &dataCacheBufferSize, unsigned ramBufferSize,
-    unsigned thread, unsigned numberOfLines, bool dumpRegisters) {
+    unsigned thread, unsigned numberOfLines, bool dumpRegisters,
+    bool errorDetection) {
 
   // Compute the sequence of instruction groups and the number of its repetions
   // to reach the desired size

--- a/src/firestarter/Environment/X86/Payload/AVX512Payload.cpp
+++ b/src/firestarter/Environment/X86/Payload/AVX512Payload.cpp
@@ -103,6 +103,7 @@ int AVX512Payload::compilePayload(
   auto l3_count_reg = r11;
   auto ram_count_reg = r12;
   auto temp_reg = r13;
+  auto temp_reg2 = rbp;
   auto offset_reg = r14;
   auto addrHigh_reg = r15;
   auto iter_reg = mm0;
@@ -110,9 +111,9 @@ int AVX512Payload::compilePayload(
   auto shift_reg32 = std::vector<Gp>({edi, esi, edx});
   auto nr_shift_regs = 3;
   auto mul_regs = 3;
-  auto add_regs = 23;
+  auto add_regs = 24;
   auto alt_dst_regs = 5;
-  auto ram_reg = zmm31;
+  auto ram_reg = zmm30;
 
   FuncDetail func;
   func.init(FuncSignatureT<unsigned long long, unsigned long long *,
@@ -127,7 +128,9 @@ int AVX512Payload::compilePayload(
   for (int i = 0; i < 32; i++) {
     frame.addDirtyRegs(Zmm(i));
   }
-  frame.addDirtyRegs(Mm(0));
+  for (int i = 0; i < 8; i++) {
+    frame.addDirtyRegs(Mm(i));
+  }
   // make all other used registers dirty except RAX
   frame.addDirtyRegs(l1_addr, l2_addr, l3_addr, ram_addr, l2_count_reg,
                      l3_count_reg, ram_count_reg, temp_reg, offset_reg,
@@ -378,6 +381,11 @@ int AVX512Payload::compilePayload(
     cb.mov(ptr_64(pointer_reg, -8), Imm(firestarter::DumpVariable::Wait));
 
     cb.bind(SkipRegistersDump);
+  }
+
+  if (errorDetection) {
+    this->emitErrorDetectionCode<decltype(iter_reg), Ymm>(cb, iter_reg,
+                                                          temp_reg, temp_reg2);
   }
 
   cb.test(ptr_64(addrHigh_reg), Imm(LOAD_HIGH));

--- a/src/firestarter/Environment/X86/Payload/AVX512Payload.cpp
+++ b/src/firestarter/Environment/X86/Payload/AVX512Payload.cpp
@@ -384,8 +384,8 @@ int AVX512Payload::compilePayload(
   }
 
   if (errorDetection) {
-    this->emitErrorDetectionCode<decltype(iter_reg), Ymm>(cb, iter_reg,
-                                                          temp_reg, temp_reg2);
+    this->emitErrorDetectionCode<decltype(iter_reg), Ymm>(
+        cb, iter_reg, pointer_reg, temp_reg, temp_reg2);
   }
 
   cb.test(ptr_64(addrHigh_reg), Imm(LOAD_HIGH));

--- a/src/firestarter/Environment/X86/Payload/AVX512Payload.cpp
+++ b/src/firestarter/Environment/X86/Payload/AVX512Payload.cpp
@@ -385,7 +385,7 @@ int AVX512Payload::compilePayload(
 
   if (errorDetection) {
     this->emitErrorDetectionCode<decltype(iter_reg), Ymm>(
-        cb, iter_reg, pointer_reg, temp_reg, temp_reg2);
+        cb, iter_reg, addrHigh_reg, pointer_reg, temp_reg, temp_reg2);
   }
 
   cb.test(ptr_64(addrHigh_reg), Imm(LOAD_HIGH));

--- a/src/firestarter/Environment/X86/Payload/AVXPayload.cpp
+++ b/src/firestarter/Environment/X86/Payload/AVXPayload.cpp
@@ -426,8 +426,8 @@ int AVXPayload::compilePayload(
   }
 
   if (errorDetection) {
-    this->emitErrorDetectionCode<decltype(iter_reg), Ymm>(cb, iter_reg,
-                                                          temp_reg, temp_reg2);
+    this->emitErrorDetectionCode<decltype(iter_reg), Ymm>(
+        cb, iter_reg, pointer_reg, temp_reg, temp_reg2);
   }
 
   cb.test(ptr_64(addrHigh_reg), Imm(LOAD_HIGH));

--- a/src/firestarter/Environment/X86/Payload/AVXPayload.cpp
+++ b/src/firestarter/Environment/X86/Payload/AVXPayload.cpp
@@ -427,7 +427,7 @@ int AVXPayload::compilePayload(
 
   if (errorDetection) {
     this->emitErrorDetectionCode<decltype(iter_reg), Ymm>(
-        cb, iter_reg, pointer_reg, temp_reg, temp_reg2);
+        cb, iter_reg, addrHigh_reg, pointer_reg, temp_reg, temp_reg2);
   }
 
   cb.test(ptr_64(addrHigh_reg), Imm(LOAD_HIGH));

--- a/src/firestarter/Environment/X86/Payload/AVXPayload.cpp
+++ b/src/firestarter/Environment/X86/Payload/AVXPayload.cpp
@@ -106,6 +106,7 @@ int AVXPayload::compilePayload(
   auto l3_count_reg = r9;
   auto ram_count_reg = r10;
   auto temp_reg = r11;
+  auto temp_reg2 = rbp;
   auto offset_reg = r12;
   auto addrHigh_reg = r13;
   auto iter_reg = r14;
@@ -132,8 +133,8 @@ int AVXPayload::compilePayload(
   }
   // make all other used registers dirty except RAX
   frame.addDirtyRegs(l1_addr, l2_addr, l3_addr, ram_addr, l2_count_reg,
-                     l3_count_reg, ram_count_reg, temp_reg, offset_reg,
-                     addrHigh_reg, iter_reg);
+                     l3_count_reg, ram_count_reg, temp_reg, temp_reg2,
+                     offset_reg, addrHigh_reg, iter_reg);
 
   FuncArgsAssignment args(&func);
   args.assignAll(pointer_reg, addrHigh_reg, iter_reg);
@@ -425,7 +426,8 @@ int AVXPayload::compilePayload(
   }
 
   if (errorDetection) {
-    this->emitErrorDetectionCode<Ymm>(cb, iter_reg, temp_reg, temp_reg2);
+    this->emitErrorDetectionCode<decltype(iter_reg), Ymm>(cb, iter_reg,
+                                                          temp_reg, temp_reg2);
   }
 
   cb.test(ptr_64(addrHigh_reg), Imm(LOAD_HIGH));

--- a/src/firestarter/Environment/X86/Payload/AVXPayload.cpp
+++ b/src/firestarter/Environment/X86/Payload/AVXPayload.cpp
@@ -424,6 +424,10 @@ int AVXPayload::compilePayload(
     cb.bind(SkipRegistersDump);
   }
 
+  if (errorDetection) {
+    this->emitErrorDetectionCode<Ymm>(cb, iter_reg, temp_reg, temp_reg2);
+  }
+
   cb.test(ptr_64(addrHigh_reg), Imm(LOAD_HIGH));
   cb.jnz(Loop);
 

--- a/src/firestarter/Environment/X86/Payload/AVXPayload.cpp
+++ b/src/firestarter/Environment/X86/Payload/AVXPayload.cpp
@@ -33,7 +33,8 @@ int AVXPayload::compilePayload(
     std::vector<std::pair<std::string, unsigned>> const &proportion,
     unsigned instructionCacheSize,
     std::list<unsigned> const &dataCacheBufferSize, unsigned ramBufferSize,
-    unsigned thread, unsigned numberOfLines, bool dumpRegisters) {
+    unsigned thread, unsigned numberOfLines, bool dumpRegisters,
+    bool errorDetection) {
   // Compute the sequence of instruction groups and the number of its repetions
   // to reach the desired size
   auto sequence = this->generateSequence(proportion);

--- a/src/firestarter/Environment/X86/Payload/FMA4Payload.cpp
+++ b/src/firestarter/Environment/X86/Payload/FMA4Payload.cpp
@@ -407,6 +407,10 @@ int FMA4Payload::compilePayload(
     cb.bind(SkipRegistersDump);
   }
 
+  if (errorDetection) {
+    this->emitErrorDetectionCode<Ymm>(cb, iter_reg, temp_reg, temp_reg2);
+  }
+
   cb.test(ptr_64(addrHigh_reg), Imm(LOAD_HIGH));
   cb.jnz(Loop);
 

--- a/src/firestarter/Environment/X86/Payload/FMA4Payload.cpp
+++ b/src/firestarter/Environment/X86/Payload/FMA4Payload.cpp
@@ -412,7 +412,7 @@ int FMA4Payload::compilePayload(
 
   if (errorDetection) {
     this->emitErrorDetectionCode<decltype(iter_reg), Ymm>(
-        cb, iter_reg, pointer_reg, temp_reg, temp_reg2);
+        cb, iter_reg, addrHigh_reg, pointer_reg, temp_reg, temp_reg2);
   }
 
   cb.test(ptr_64(addrHigh_reg), Imm(LOAD_HIGH));

--- a/src/firestarter/Environment/X86/Payload/FMA4Payload.cpp
+++ b/src/firestarter/Environment/X86/Payload/FMA4Payload.cpp
@@ -411,8 +411,8 @@ int FMA4Payload::compilePayload(
   }
 
   if (errorDetection) {
-    this->emitErrorDetectionCode<decltype(iter_reg), Ymm>(cb, iter_reg,
-                                                          temp_reg, temp_reg2);
+    this->emitErrorDetectionCode<decltype(iter_reg), Ymm>(
+        cb, iter_reg, pointer_reg, temp_reg, temp_reg2);
   }
 
   cb.test(ptr_64(addrHigh_reg), Imm(LOAD_HIGH));

--- a/src/firestarter/Environment/X86/Payload/FMA4Payload.cpp
+++ b/src/firestarter/Environment/X86/Payload/FMA4Payload.cpp
@@ -106,6 +106,7 @@ int FMA4Payload::compilePayload(
   auto l3_count_reg = r11;
   auto ram_count_reg = r12;
   auto temp_reg = r13;
+  auto temp_reg2 = rbp;
   auto offset_reg = r14;
   auto addrHigh_reg = r15;
   auto iter_reg = mm0;
@@ -130,11 +131,13 @@ int FMA4Payload::compilePayload(
   for (int i = 0; i < 16; i++) {
     frame.addDirtyRegs(Ymm(i));
   }
-  frame.addDirtyRegs(Mm(0));
+  for (int i = 0; i < 8; i++) {
+    frame.addDirtyRegs(Mm(i));
+  }
   // make all other used registers dirty except RAX
   frame.addDirtyRegs(l1_addr, l2_addr, l3_addr, ram_addr, l2_count_reg,
-                     l3_count_reg, ram_count_reg, temp_reg, offset_reg,
-                     addrHigh_reg, iter_reg, ram_addr);
+                     l3_count_reg, ram_count_reg, temp_reg, temp_reg2,
+                     offset_reg, addrHigh_reg, iter_reg, ram_addr);
   for (const auto &reg : shift_reg) {
     frame.addDirtyRegs(reg);
   }
@@ -408,7 +411,8 @@ int FMA4Payload::compilePayload(
   }
 
   if (errorDetection) {
-    this->emitErrorDetectionCode<Ymm>(cb, iter_reg, temp_reg, temp_reg2);
+    this->emitErrorDetectionCode<decltype(iter_reg), Ymm>(cb, iter_reg,
+                                                          temp_reg, temp_reg2);
   }
 
   cb.test(ptr_64(addrHigh_reg), Imm(LOAD_HIGH));

--- a/src/firestarter/Environment/X86/Payload/FMA4Payload.cpp
+++ b/src/firestarter/Environment/X86/Payload/FMA4Payload.cpp
@@ -33,7 +33,8 @@ int FMA4Payload::compilePayload(
     std::vector<std::pair<std::string, unsigned>> const &proportion,
     unsigned instructionCacheSize,
     std::list<unsigned> const &dataCacheBufferSize, unsigned ramBufferSize,
-    unsigned thread, unsigned numberOfLines, bool dumpRegisters) {
+    unsigned thread, unsigned numberOfLines, bool dumpRegisters,
+    bool errorDetection) {
   // Compute the sequence of instruction groups and the number of its repetions
   // to reach the desired size
   auto sequence = this->generateSequence(proportion);

--- a/src/firestarter/Environment/X86/Payload/FMAPayload.cpp
+++ b/src/firestarter/Environment/X86/Payload/FMAPayload.cpp
@@ -420,8 +420,8 @@ int FMAPayload::compilePayload(
   }
 
   if (errorDetection) {
-    this->emitErrorDetectionCode<decltype(iter_reg), Ymm>(cb, iter_reg,
-                                                          temp_reg, temp_reg2);
+    this->emitErrorDetectionCode<decltype(iter_reg), Ymm>(
+        cb, iter_reg, pointer_reg, temp_reg, temp_reg2);
   }
 
   cb.test(ptr_64(addrHigh_reg), Imm(LOAD_HIGH));

--- a/src/firestarter/Environment/X86/Payload/FMAPayload.cpp
+++ b/src/firestarter/Environment/X86/Payload/FMAPayload.cpp
@@ -421,7 +421,7 @@ int FMAPayload::compilePayload(
 
   if (errorDetection) {
     this->emitErrorDetectionCode<decltype(iter_reg), Ymm>(
-        cb, iter_reg, pointer_reg, temp_reg, temp_reg2);
+        cb, iter_reg, addrHigh_reg, pointer_reg, temp_reg, temp_reg2);
   }
 
   cb.test(ptr_64(addrHigh_reg), Imm(LOAD_HIGH));

--- a/src/firestarter/Environment/X86/Payload/FMAPayload.cpp
+++ b/src/firestarter/Environment/X86/Payload/FMAPayload.cpp
@@ -420,7 +420,8 @@ int FMAPayload::compilePayload(
   }
 
   if (errorDetection) {
-    this->emitErrorDetectionCode<Ymm>(cb, iter_reg, temp_reg, temp_reg2);
+    this->emitErrorDetectionCode<decltype(iter_reg), Ymm>(cb, iter_reg,
+                                                          temp_reg, temp_reg2);
   }
 
   cb.test(ptr_64(addrHigh_reg), Imm(LOAD_HIGH));

--- a/src/firestarter/Environment/X86/Payload/SSE2Payload.cpp
+++ b/src/firestarter/Environment/X86/Payload/SSE2Payload.cpp
@@ -415,6 +415,10 @@ int SSE2Payload::compilePayload(
     cb.bind(SkipRegistersDump);
   }
 
+  if (errorDetection) {
+    this->emitErrorDetectionCode<Xmm>(cb, iter_reg, temp_reg, temp_reg2);
+  }
+
   cb.test(ptr_64(addrHigh_reg), Imm(LOAD_HIGH));
   cb.jnz(Loop);
 

--- a/src/firestarter/Environment/X86/Payload/SSE2Payload.cpp
+++ b/src/firestarter/Environment/X86/Payload/SSE2Payload.cpp
@@ -33,7 +33,8 @@ int SSE2Payload::compilePayload(
     std::vector<std::pair<std::string, unsigned>> const &proportion,
     unsigned instructionCacheSize,
     std::list<unsigned> const &dataCacheBufferSize, unsigned ramBufferSize,
-    unsigned thread, unsigned numberOfLines, bool dumpRegisters) {
+    unsigned thread, unsigned numberOfLines, bool dumpRegisters,
+    bool errorDetection) {
   // Compute the sequence of instruction groups and the number of its repetions
   // to reach the desired size
   auto sequence = this->generateSequence(proportion);

--- a/src/firestarter/Environment/X86/Payload/SSE2Payload.cpp
+++ b/src/firestarter/Environment/X86/Payload/SSE2Payload.cpp
@@ -417,8 +417,8 @@ int SSE2Payload::compilePayload(
   }
 
   if (errorDetection) {
-    this->emitErrorDetectionCode<decltype(iter_reg), Xmm>(cb, iter_reg,
-                                                          temp_reg, temp_reg2);
+    this->emitErrorDetectionCode<decltype(iter_reg), Xmm>(
+        cb, iter_reg, pointer_reg, temp_reg, temp_reg2);
   }
 
   cb.test(ptr_64(addrHigh_reg), Imm(LOAD_HIGH));

--- a/src/firestarter/Environment/X86/Payload/SSE2Payload.cpp
+++ b/src/firestarter/Environment/X86/Payload/SSE2Payload.cpp
@@ -418,7 +418,7 @@ int SSE2Payload::compilePayload(
 
   if (errorDetection) {
     this->emitErrorDetectionCode<decltype(iter_reg), Xmm>(
-        cb, iter_reg, pointer_reg, temp_reg, temp_reg2);
+        cb, iter_reg, addrHigh_reg, pointer_reg, temp_reg, temp_reg2);
   }
 
   cb.test(ptr_64(addrHigh_reg), Imm(LOAD_HIGH));

--- a/src/firestarter/Environment/X86/Payload/SSE2Payload.cpp
+++ b/src/firestarter/Environment/X86/Payload/SSE2Payload.cpp
@@ -106,6 +106,7 @@ int SSE2Payload::compilePayload(
   auto l3_count_reg = r9;
   auto ram_count_reg = r10;
   auto temp_reg = r11;
+  auto temp_reg2 = rbp;
   auto offset_reg = r12;
   auto addrHigh_reg = r13;
   auto iter_reg = r14;
@@ -132,8 +133,8 @@ int SSE2Payload::compilePayload(
   }
   // make all other used registers dirty except RAX
   frame.addDirtyRegs(l1_addr, l2_addr, l3_addr, ram_addr, l2_count_reg,
-                     l3_count_reg, ram_count_reg, temp_reg, offset_reg,
-                     addrHigh_reg, iter_reg);
+                     l3_count_reg, ram_count_reg, temp_reg, temp_reg2,
+                     offset_reg, addrHigh_reg, iter_reg);
 
   FuncArgsAssignment args(&func);
   args.assignAll(pointer_reg, addrHigh_reg, iter_reg);
@@ -416,7 +417,8 @@ int SSE2Payload::compilePayload(
   }
 
   if (errorDetection) {
-    this->emitErrorDetectionCode<Xmm>(cb, iter_reg, temp_reg, temp_reg2);
+    this->emitErrorDetectionCode<decltype(iter_reg), Xmm>(cb, iter_reg,
+                                                          temp_reg, temp_reg2);
   }
 
   cb.test(ptr_64(addrHigh_reg), Imm(LOAD_HIGH));

--- a/src/firestarter/Environment/X86/Payload/X86Payload.cpp
+++ b/src/firestarter/Environment/X86/Payload/X86Payload.cpp
@@ -342,10 +342,10 @@ void X86Payload::emitErrorDetectionCode(asmjit::x86::Builder &cb,
 
     cb.mov(asmjit::x86::ptr_64(asmjit::x86::r9, 0), asmjit::x86::rcx);
     cb.mov(asmjit::x86::ptr_64(asmjit::x86::r9, 8), asmjit::x86::rbx);
-    cb.movq(asmjit::x86::ptr_64(asmjit::x86::r9, 16), asmjit::Imm(0));
-    cb.movq(asmjit::x86::ptr_64(asmjit::x86::r9, 24), asmjit::Imm(0));
+    cb.mov(asmjit::x86::ptr_64(asmjit::x86::r9, 16), asmjit::Imm(0));
+    cb.mov(asmjit::x86::ptr_64(asmjit::x86::r9, 24), asmjit::Imm(0));
 
-    cb.movq(asmjit::x86::rax, asmjit::Imm(2));
+    cb.mov(asmjit::x86::rax, asmjit::Imm(2));
 
     auto L6 = cb.newLabel();
     cb.jmp(L6);
@@ -366,9 +366,9 @@ void X86Payload::emitErrorDetectionCode(asmjit::x86::Builder &cb,
 
     auto L3 = cb.newLabel();
 
-    cb.cmpq(asmjit::x86::ptr_64(asmjit::x86::r9, 16), asmjit::Imm(0));
+    cb.cmp(asmjit::x86::ptr_64(asmjit::x86::r9, 16), asmjit::Imm(0));
     cb.jne(L3);
-    cb.cmpq(asmjit::x86::ptr_64(asmjit::x86::r9, 24), asmjit::Imm(0));
+    cb.cmp(asmjit::x86::ptr_64(asmjit::x86::r9, 24), asmjit::Imm(0));
     cb.jne(L3);
 
     cb.mov(asmjit::x86::ptr_64(asmjit::x86::r9, 16), asmjit::x86::rdx);
@@ -377,28 +377,38 @@ void X86Payload::emitErrorDetectionCode(asmjit::x86::Builder &cb,
     cb.bind(L3);
 
     cb.cmp(asmjit::x86::rcx, asmjit::x86::ptr_64(asmjit::x86::r9, 16));
-    cb.movq(asmjit::x86::rax, asmjit::Imm(4));
+    cb.mov(asmjit::x86::rax, asmjit::Imm(4));
     cb.jne(L6);
 
     cb.cmp(asmjit::x86::rbx, asmjit::x86::ptr_64(asmjit::x86::r9, 24));
     auto L4 = cb.newLabel();
     cb.jne(L4);
 
-    cb.movq(asmjit::x86::rax, asmjit::Imm(0));
+    cb.mov(asmjit::x86::rax, asmjit::Imm(0));
 
     auto L5 = cb.newLabel();
     cb.jmp(L5);
 
     cb.bind(L4);
 
-    cb.movq(asmjit::x86::rax, asmjit::Imm(1));
+    cb.mov(asmjit::x86::rax, asmjit::Imm(1));
 
     cb.bind(L5);
 
-    cb.movq(asmjit::x86::ptr_64(asmjit::x86::r9, 16), asmjit::Imm(0));
-    cb.movq(asmjit::x86::ptr_64(asmjit::x86::r9, 24), asmjit::Imm(0));
+    cb.mov(asmjit::x86::ptr_64(asmjit::x86::r9, 16), asmjit::Imm(0));
+    cb.mov(asmjit::x86::ptr_64(asmjit::x86::r9, 24), asmjit::Imm(0));
 
     cb.bind(L6);
+
+    // if check failed
+    cb.cmp(asmjit::x86::rax, asmjit::Imm(1));
+    auto L7 = cb.newLabel();
+    cb.jne(L7);
+
+    // write the error flag
+    cb.mov(asmjit::x86::ptr_64(asmjit::x86::r9, 32), asmjit::Imm(1));
+
+    cb.bind(L7);
   };
 
   // left communication
@@ -434,17 +444,21 @@ void X86Payload::emitErrorDetectionCode(asmjit::x86::Builder &cb,
 template void
 X86Payload::emitErrorDetectionCode<asmjit::x86::Gpq, asmjit::x86::Xmm>(
     asmjit::x86::Builder &cb, asmjit::x86::Gpq iter_reg,
-    asmjit::x86::Gpq temp_reg, asmjit::x86::Gpq temp_reg2);
+    asmjit::x86::Gpq pointer_reg, asmjit::x86::Gpq temp_reg,
+    asmjit::x86::Gpq temp_reg2);
 template void
 X86Payload::emitErrorDetectionCode<asmjit::x86::Gpq, asmjit::x86::Ymm>(
     asmjit::x86::Builder &cb, asmjit::x86::Gpq iter_reg,
-    asmjit::x86::Gpq temp_reg, asmjit::x86::Gpq temp_reg2);
+    asmjit::x86::Gpq pointer_reg, asmjit::x86::Gpq temp_reg,
+    asmjit::x86::Gpq temp_reg2);
 
 template void
 X86Payload::emitErrorDetectionCode<asmjit::x86::Mm, asmjit::x86::Ymm>(
     asmjit::x86::Builder &cb, asmjit::x86::Mm iter_reg,
-    asmjit::x86::Gpq temp_reg, asmjit::x86::Gpq temp_reg2);
+    asmjit::x86::Gpq pointer_reg, asmjit::x86::Gpq temp_reg,
+    asmjit::x86::Gpq temp_reg2);
 template void
 X86Payload::emitErrorDetectionCode<asmjit::x86::Mm, asmjit::x86::Zmm>(
     asmjit::x86::Builder &cb, asmjit::x86::Mm iter_reg,
-    asmjit::x86::Gpq temp_reg, asmjit::x86::Gpq temp_reg2);
+    asmjit::x86::Gpq pointer_reg, asmjit::x86::Gpq temp_reg,
+    asmjit::x86::Gpq temp_reg2);

--- a/src/firestarter/Environment/X86/Payload/X86Payload.cpp
+++ b/src/firestarter/Environment/X86/Payload/X86Payload.cpp
@@ -313,10 +313,20 @@ void X86Payload::emitErrorDetectionCode(asmjit::x86::Builder &cb,
   // different (changing) speed, with just one "lock cmpxchg16b" Brought to you
   // by a few hours of headache for two people.
   auto communication = [&](auto offset) {
+    // move hash
+    cb.mov(asmjit::x86::rbx, temp_reg);
+    // move iterations counter
+    if constexpr (std::is_same<asmjit::x86::Mm, IterReg>::value) {
+      cb.movq(asmjit::x86::rcx, iter_reg);
+    } else {
+      cb.mov(asmjit::x86::rcx, iter_reg);
+    }
+
     // communication
     cb.mov(asmjit::x86::r8, asmjit::x86::ptr_64(temp_reg2, offset));
     // temp data
-    cb.mov(asmjit::x86::r9, asmjit::x86::ptr_64(temp_reg2, offset + 8));
+    cb.mov(asmjit::x86::r9, temp_reg2);
+    cb.add(asmjit::x86::r9, asmjit::Imm(offset + 8));
 
     cb.mov(asmjit::x86::rdx, asmjit::x86::ptr_64(asmjit::x86::r9, 0));
     cb.mov(asmjit::x86::rax, asmjit::x86::ptr_64(asmjit::x86::r9, 8));

--- a/src/firestarter/Environment/X86/Payload/X86Payload.cpp
+++ b/src/firestarter/Environment/X86/Payload/X86Payload.cpp
@@ -21,6 +21,7 @@
 
 #include <chrono>
 #include <thread>
+#include <type_traits>
 
 #ifdef _MSC_VER
 #include <array>
@@ -88,4 +89,108 @@ X86Payload::highLoadFunction(unsigned long long *addrMem,
                              volatile unsigned long long *addrHigh,
                              unsigned long long iterations) {
   return this->loadFunction(addrMem, addrHigh, iterations);
+}
+
+// add MM regs to dirty regs
+template <>
+void X86Payload::emitErrorDetectionCode<asmjit::x86::Ymm>(
+    asmjit::x86::Builder &cb, asmjit::x86::Mm iter_reg,
+    asmjit::x86::Gp temp_reg, asmjit::x86::Gp temp_reg2) {
+  // static_assert(std::is_base_of<asmjit::x86::Vec, Vec>::value, "Vec must be
+  // of asmjit::asmjit::x86::Vec");
+  assert(((iter_reg == asmjit::x86::mm0),
+          "iter_reg must be asmjit::asmjit::x86::mm0"));
+
+  // TODO: implement for xmm and zmm
+  // static_assert(std::is_same<asmjit::x86::Ymm, Vec>::value, "Not implemented
+  // for any other type than asmjit::asmjit::x86::Ymm");
+
+  // do the error detection every 1024 (2**10) iterations
+  // check if lower 10 bits eq 0
+  auto SkipErrorDetection = cb.newLabel();
+
+  cb.movq(temp_reg, iter_reg);
+  cb.and_(temp_reg, asmjit::Imm(0x3ff));
+  cb.test(temp_reg, asmjit::Imm(0));
+  cb.jnz(SkipErrorDetection);
+
+  // ONLY IF ZMM ?
+#if 0
+			// 0. move mm0 (iter_reg) to temp_reg
+			cb.movq(temp_reg, iter_reg);
+#endif
+  cb.mov(temp_reg, asmjit::Imm(0xffffffff));
+
+  // 1. use mm to backup vector registers 0
+  cb.movq(temp_reg2, asmjit::x86::xmm0);
+  cb.movq(asmjit::x86::Mm(7), temp_reg2);
+  cb.crc32(temp_reg, temp_reg2);
+  cb.movhlps(asmjit::x86::xmm0, asmjit::x86::xmm0);
+  cb.movq(temp_reg2, asmjit::x86::xmm0);
+  cb.movq(asmjit::x86::Mm(6), temp_reg2);
+  cb.crc32(temp_reg, temp_reg2);
+
+  cb.vextractf128(asmjit::x86::xmm0, asmjit::x86::ymm0, asmjit::Imm(1));
+
+  cb.movq(temp_reg2, asmjit::x86::xmm0);
+  cb.movq(asmjit::x86::Mm(5), temp_reg2);
+  cb.crc32(temp_reg, temp_reg2);
+  cb.movhlps(asmjit::x86::xmm0, asmjit::x86::xmm0);
+  cb.movq(temp_reg2, asmjit::x86::xmm0);
+  cb.movq(asmjit::x86::Mm(4), temp_reg2);
+  cb.crc32(temp_reg, temp_reg2);
+
+  // 1. calculate the hash
+  for (int i = 1; i < (int)this->registerCount(); i++) {
+    // mov vector[i] to vector[0]
+    cb.vmovapd(asmjit::x86::ymm0, asmjit::x86::Ymm(i));
+
+    // calculate hash
+    cb.movq(temp_reg2, asmjit::x86::xmm0);
+    cb.crc32(temp_reg, temp_reg2);
+    cb.movhlps(asmjit::x86::xmm0, asmjit::x86::xmm0);
+    cb.movq(temp_reg2, asmjit::x86::xmm0);
+    cb.crc32(temp_reg, temp_reg2);
+
+    cb.vextractf128(asmjit::x86::xmm0, asmjit::x86::ymm0, asmjit::Imm(1));
+
+    cb.movq(temp_reg2, asmjit::x86::xmm0);
+    cb.crc32(temp_reg, temp_reg2);
+    cb.movhlps(asmjit::x86::xmm0, asmjit::x86::xmm0);
+    cb.movq(temp_reg2, asmjit::x86::xmm0);
+    cb.crc32(temp_reg, temp_reg2);
+  }
+
+  // N-1. restore vector register 0 from backup
+  cb.movq(temp_reg2, asmjit::x86::Mm(5));
+  cb.movq(asmjit::x86::xmm0, temp_reg2);
+  cb.movq(temp_reg2, asmjit::x86::Mm(4));
+  cb.pinsrq(asmjit::x86::xmm0, temp_reg2, asmjit::Imm(1));
+
+  cb.vinsertf128(asmjit::x86::ymm0, asmjit::x86::ymm0, asmjit::x86::xmm0,
+                 asmjit::Imm(1));
+
+  cb.movq(temp_reg2, asmjit::x86::Mm(7));
+  cb.movq(asmjit::x86::xmm0, temp_reg2);
+  cb.movq(temp_reg2, asmjit::x86::Mm(6));
+  cb.pinsrq(asmjit::x86::xmm0, temp_reg2, asmjit::Imm(1));
+
+  // before starting the communication, backup rax, rbx, rcx and rdx to mm[0:3]
+  cb.movq(asmjit::x86::Mm(7), asmjit::x86::rax);
+  cb.movq(asmjit::x86::Mm(6), asmjit::x86::rbx);
+  cb.movq(asmjit::x86::Mm(5), asmjit::x86::rcx);
+  cb.movq(asmjit::x86::Mm(4), asmjit::x86::rdx);
+
+  // communication
+
+  // restore rax, rbx, rcx and rdx from mm[0:3]
+  cb.movq(asmjit::x86::rax, asmjit::x86::Mm(7));
+  cb.movq(asmjit::x86::rbx, asmjit::x86::Mm(6));
+  cb.movq(asmjit::x86::rcx, asmjit::x86::Mm(5));
+  cb.movq(asmjit::x86::rdx, asmjit::x86::Mm(4));
+
+  // N. move temp_reg back to iter_reg
+  cb.movq(iter_reg, temp_reg);
+
+  cb.bind(SkipErrorDetection);
 }

--- a/src/firestarter/Environment/X86/Payload/ZENFMAPayload.cpp
+++ b/src/firestarter/Environment/X86/Payload/ZENFMAPayload.cpp
@@ -375,8 +375,8 @@ int ZENFMAPayload::compilePayload(
   }
 
   if (errorDetection) {
-    this->emitErrorDetectionCode<decltype(iter_reg), Ymm>(cb, iter_reg,
-                                                          temp_reg, temp_reg2);
+    this->emitErrorDetectionCode<decltype(iter_reg), Ymm>(
+        cb, iter_reg, pointer_reg, temp_reg, temp_reg2);
   }
 
   cb.test(ptr_64(addrHigh_reg), Imm(LOAD_HIGH));

--- a/src/firestarter/Environment/X86/Payload/ZENFMAPayload.cpp
+++ b/src/firestarter/Environment/X86/Payload/ZENFMAPayload.cpp
@@ -371,6 +371,10 @@ int ZENFMAPayload::compilePayload(
     cb.bind(SkipRegistersDump);
   }
 
+  if (errorDetection) {
+    this->emitErrorDetectionCode<Ymm>(cb, iter_reg, temp_reg, temp_reg2);
+  }
+
   cb.test(ptr_64(addrHigh_reg), Imm(LOAD_HIGH));
   cb.jnz(Loop);
 

--- a/src/firestarter/Environment/X86/Payload/ZENFMAPayload.cpp
+++ b/src/firestarter/Environment/X86/Payload/ZENFMAPayload.cpp
@@ -106,6 +106,7 @@ int ZENFMAPayload::compilePayload(
   auto l3_count_reg = r11;
   auto ram_count_reg = r12;
   auto temp_reg = r13;
+  auto temp_reg2 = rbp;
   auto offset_reg = r14;
   auto addrHigh_reg = r15;
   auto iter_reg = mm0;
@@ -127,11 +128,13 @@ int ZENFMAPayload::compilePayload(
   for (int i = 0; i < 16; i++) {
     frame.addDirtyRegs(Ymm(i));
   }
-  frame.addDirtyRegs(Mm(0));
+  for (int i = 0; i < 8; i++) {
+    frame.addDirtyRegs(Mm(i));
+  }
   // make all other used registers dirty except RAX
   frame.addDirtyRegs(l1_addr, l2_addr, l3_addr, ram_addr, l2_count_reg,
-                     l3_count_reg, ram_count_reg, temp_reg, offset_reg,
-                     addrHigh_reg, iter_reg, ram_addr);
+                     l3_count_reg, ram_count_reg, temp_reg, temp_reg2,
+                     offset_reg, addrHigh_reg, iter_reg, ram_addr);
   for (const auto &reg : shift_reg) {
     frame.addDirtyRegs(reg);
   }
@@ -372,7 +375,8 @@ int ZENFMAPayload::compilePayload(
   }
 
   if (errorDetection) {
-    this->emitErrorDetectionCode<Ymm>(cb, iter_reg, temp_reg, temp_reg2);
+    this->emitErrorDetectionCode<decltype(iter_reg), Ymm>(cb, iter_reg,
+                                                          temp_reg, temp_reg2);
   }
 
   cb.test(ptr_64(addrHigh_reg), Imm(LOAD_HIGH));

--- a/src/firestarter/Environment/X86/Payload/ZENFMAPayload.cpp
+++ b/src/firestarter/Environment/X86/Payload/ZENFMAPayload.cpp
@@ -33,7 +33,8 @@ int ZENFMAPayload::compilePayload(
     std::vector<std::pair<std::string, unsigned>> const &proportion,
     unsigned instructionCacheSize,
     std::list<unsigned> const &dataCacheBufferSize, unsigned ramBufferSize,
-    unsigned thread, unsigned numberOfLines, bool dumpRegisters) {
+    unsigned thread, unsigned numberOfLines, bool dumpRegisters,
+    bool errorDetection) {
   // Compute the sequence of instruction groups and the number of its repetions
   // to reach the desired size
   auto sequence = this->generateSequence(proportion);

--- a/src/firestarter/Environment/X86/Payload/ZENFMAPayload.cpp
+++ b/src/firestarter/Environment/X86/Payload/ZENFMAPayload.cpp
@@ -376,7 +376,7 @@ int ZENFMAPayload::compilePayload(
 
   if (errorDetection) {
     this->emitErrorDetectionCode<decltype(iter_reg), Ymm>(
-        cb, iter_reg, pointer_reg, temp_reg, temp_reg2);
+        cb, iter_reg, addrHigh_reg, pointer_reg, temp_reg, temp_reg2);
   }
 
   cb.test(ptr_64(addrHigh_reg), Imm(LOAD_HIGH));

--- a/src/firestarter/Firestarter.cpp
+++ b/src/firestarter/Firestarter.cpp
@@ -50,8 +50,9 @@ Firestarter::Firestarter(
     std::string const &instructionGroups, unsigned lineCount,
     bool allowUnavailablePayload, bool dumpRegisters,
     std::chrono::seconds const &dumpRegistersTimeDelta,
-    std::string const &dumpRegistersOutpath, int gpus, unsigned gpuMatrixSize,
-    bool gpuUseFloat, bool gpuUseDouble, bool listMetrics, bool measurement,
+    std::string const &dumpRegistersOutpath, bool errorDetection, int gpus,
+    unsigned gpuMatrixSize, bool gpuUseFloat, bool gpuUseDouble,
+    bool listMetrics, bool measurement,
     std::chrono::milliseconds const &startDelta,
     std::chrono::milliseconds const &stopDelta,
     std::chrono::milliseconds const &measurementInterval,
@@ -66,7 +67,8 @@ Firestarter::Firestarter(
     : _argc(argc), _argv(argv), _timeout(timeout), _loadPercent(loadPercent),
       _period(period), _dumpRegisters(dumpRegisters),
       _dumpRegistersTimeDelta(dumpRegistersTimeDelta),
-      _dumpRegistersOutpath(dumpRegistersOutpath), _gpus(gpus),
+      _dumpRegistersOutpath(dumpRegistersOutpath),
+      _errorDetection(errorDetection), _gpus(gpus),
       _gpuMatrixSize(gpuMatrixSize), _gpuUseFloat(gpuUseFloat),
       _gpuUseDouble(gpuUseDouble), _startDelta(startDelta),
       _stopDelta(stopDelta), _measurement(measurement), _optimize(optimize),
@@ -280,9 +282,8 @@ Firestarter::Firestarter(
 
   // setup thread with either high or low load configured at the start
   // low loads has to know the length of the period
-  if (EXIT_SUCCESS !=
-      (returnCode = this->initLoadWorkers((_loadPercent == 0), _period.count(),
-                                          _dumpRegisters))) {
+  if (EXIT_SUCCESS != (returnCode = this->initLoadWorkers((_loadPercent == 0),
+                                                          _period.count()))) {
     std::exit(returnCode);
   }
 #endif

--- a/src/firestarter/Firestarter.cpp
+++ b/src/firestarter/Firestarter.cpp
@@ -103,6 +103,17 @@ Firestarter::Firestarter(
     std::exit(returnCode);
   }
 
+#if defined(__i386__) || defined(_M_IX86) || defined(__x86_64__) ||            \
+    defined(_M_X64)
+  // Error detection uses crc32 instruction added by the SSE4.2 extension to x86
+  if (_errorDetection) {
+    if (!_environment->topology().featuresAsmjit().hasSSE4_2()) {
+      throw std::invalid_argument("Option --error-detection requires the crc32 "
+                                  "instruction added with SSE_4_2.\n");
+    }
+  }
+#endif
+
   if (_errorDetection && this->environment().requestedNumThreads() < 2) {
     throw std::invalid_argument(
         "Option --error-detection must run with 2 or more threads. Number of "

--- a/src/firestarter/Firestarter.cpp
+++ b/src/firestarter/Firestarter.cpp
@@ -103,6 +103,13 @@ Firestarter::Firestarter(
     std::exit(returnCode);
   }
 
+  if (_errorDetection && this->environment().requestedNumThreads() < 2) {
+    throw std::invalid_argument(
+        "Option --error-detection must run with 2 or more threads. Number of "
+        "threads is " +
+        std::to_string(this->environment().requestedNumThreads()) + "\n");
+  }
+
   this->environment().evaluateFunctions();
 
   if (printFunctionSummary) {

--- a/src/firestarter/Firestarter.cpp
+++ b/src/firestarter/Firestarter.cpp
@@ -399,6 +399,10 @@ void Firestarter::mainThread() {
   }
 #endif
 #endif
+
+  if (_errorDetection) {
+    this->printThreadErrorReport();
+  }
 }
 
 void Firestarter::setLoad(unsigned long long value) {

--- a/src/firestarter/LoadWorker.cpp
+++ b/src/firestarter/LoadWorker.cpp
@@ -61,8 +61,7 @@ extern "C" {
 
 using namespace firestarter;
 
-int Firestarter::initLoadWorkers(bool lowLoad, unsigned long long period,
-                                 bool dumpRegisters) {
+int Firestarter::initLoadWorkers(bool lowLoad, unsigned long long period) {
   int returnCode;
 
   if (EXIT_SUCCESS != (returnCode = this->environment().setCpuAffinity(0))) {
@@ -75,8 +74,9 @@ int Firestarter::initLoadWorkers(bool lowLoad, unsigned long long period,
 
   for (unsigned long long i = 0; i < this->environment().requestedNumThreads();
        i++) {
-    auto td = std::make_shared<LoadWorkerData>(
-        i, this->environment(), &this->loadVar, period, dumpRegisters);
+    auto td = std::make_shared<LoadWorkerData>(i, this->environment(),
+                                               &this->loadVar, period,
+                                               _dumpRegisters, _errorDetection);
 
     auto dataCacheSizeIt =
         td->config().platformConfig().dataCacheBufferSize().begin();
@@ -270,7 +270,8 @@ void Firestarter::loadThreadWorker(std::shared_ptr<LoadWorkerData> td) {
       td->config().payload().compilePayload(
           td->config().payloadSettings(), td->config().instructionCacheSize(),
           td->config().dataCacheBufferSize(), td->config().ramBufferSize(),
-          td->config().thread(), td->config().lines(), td->dumpRegisters);
+          td->config().thread(), td->config().lines(), td->dumpRegisters,
+          td->errorDetection);
 
       // allocate memory
       // if we should dump some registers, we use the first part of the memory
@@ -350,7 +351,8 @@ void Firestarter::loadThreadWorker(std::shared_ptr<LoadWorkerData> td) {
       td->config().payload().compilePayload(
           td->config().payloadSettings(), td->config().instructionCacheSize(),
           td->config().dataCacheBufferSize(), td->config().ramBufferSize(),
-          td->config().thread(), td->config().lines(), td->dumpRegisters);
+          td->config().thread(), td->config().lines(), td->dumpRegisters,
+          td->errorDetection);
 
       // call init function
       td->config().payload().init(td->addrMem, td->buffersizeMem);

--- a/src/firestarter/LoadWorker.cpp
+++ b/src/firestarter/LoadWorker.cpp
@@ -19,6 +19,7 @@
  * Contact: daniel.hackenberg@tu-dresden.de
  *****************************************************************************/
 
+#include <firestarter/ErrorDetectionStruct.hpp>
 #include <firestarter/Firestarter.hpp>
 #include <firestarter/Logging/Log.hpp>
 
@@ -40,25 +41,6 @@ extern "C" {
 #include <functional>
 #include <thread>
 
-#define PAD_SIZE(size, align)                                                  \
-  align *(int)std::ceil((double)size / (double)align)
-
-#if defined(__APPLE__)
-#define ALIGNED_MALLOC(size, align) aligned_alloc(align, PAD_SIZE(size, align))
-#define ALIGNED_FREE free
-#elif defined(__MINGW64__)
-#define ALIGNED_MALLOC(size, align) _mm_malloc(PAD_SIZE(size, align), align)
-#define ALIGNED_FREE _mm_free
-#elif defined(_MSC_VER)
-#define ALIGNED_MALLOC(size, align)                                            \
-  _aligned_malloc(PAD_SIZE(size, align), align)
-#define ALIGNED_FREE _aligned_free
-#else
-#define ALIGNED_MALLOC(size, align)                                            \
-  std::aligned_alloc(align, PAD_SIZE(size, align))
-#define ALIGNED_FREE std::free
-#endif
-
 using namespace firestarter;
 
 int Firestarter::initLoadWorkers(bool lowLoad, unsigned long long period) {
@@ -72,11 +54,34 @@ int Firestarter::initLoadWorkers(bool lowLoad, unsigned long long period) {
   // work.
   this->loadVar = lowLoad ? LOAD_LOW : LOAD_HIGH;
 
-  for (unsigned long long i = 0; i < this->environment().requestedNumThreads();
-       i++) {
+  auto numThreads = this->environment().requestedNumThreads();
+
+  // create a std::vector<std::shared_ptr<>> of requestenNumThreads()
+  // communication pointers and add these to the threaddata
+  for (unsigned long long i = 0; i < numThreads; i++) {
+    auto commPtr = reinterpret_cast<unsigned long long *>(
+        ALIGNED_MALLOC(2 * sizeof(unsigned long long), 64));
+    assert(commPtr);
+    this->errorCommunication.push_back(
+        std::shared_ptr<unsigned long long>(commPtr));
+    log::debug() << "Threads " << (i + numThreads - 1) % numThreads << " and "
+                 << i << " commPtr = 0x" << std::setfill('0')
+                 << std::setw(sizeof(unsigned long long) * 2) << std::hex
+                 << (unsigned long long)commPtr;
+  }
+
+  for (unsigned long long i = 0; i < numThreads; i++) {
     auto td = std::make_shared<LoadWorkerData>(i, this->environment(),
                                                &this->loadVar, period,
                                                _dumpRegisters, _errorDetection);
+
+    if (_errorDetection) {
+      // distribute pointers for error deteciton. (set threads in a ring)
+      // give this thread the left pointer i and right pointer (i+1) %
+      // requestedNumThreads().
+      td->setErrorCommunication(this->errorCommunication[i],
+                                this->errorCommunication[(i + 1) % numThreads]);
+    }
 
     auto dataCacheSizeIt =
         td->config().platformConfig().dataCacheBufferSize().begin();
@@ -141,6 +146,35 @@ void Firestarter::joinLoadWorkers() {
   // wait for threads after watchdog has requested termination
   for (auto &thread : this->loadThreads) {
     thread.first.join();
+  }
+}
+
+void Firestarter::printThreadErrorReport() {
+  if (_errorDetection) {
+    auto maxSize = this->loadThreads.size();
+
+    std::vector<bool> errors(maxSize, false);
+
+    for (decltype(maxSize) i = 0; i < maxSize; i++) {
+      auto errorDetectionStruct =
+          this->loadThreads[i].second->errorDetectionStruct();
+
+      if (errorDetectionStruct->errorLeft) {
+        errors[(i + maxSize - 1) % maxSize] = true;
+      }
+      if (errorDetectionStruct->errorRight) {
+        errors[i] = true;
+      }
+    }
+
+    for (decltype(maxSize) i = 0; i < maxSize; i++) {
+      if (errors[i]) {
+        log::fatal()
+            << "Data mismatch between Threads " << i << " and "
+            << (i + 1) % maxSize
+            << ".\n       This may be caused by bit-flips in the hardware.";
+      }
+    }
   }
 }
 
@@ -231,15 +265,6 @@ void Firestarter::loadThreadWorker(std::shared_ptr<LoadWorkerData> td) {
 
   int old = THREAD_WAIT;
 
-  // use REGISTER_MAX_NUM cache lines for the dumped registers
-  // and another cache line for the control variable.
-  // as we are doing aligned moves we only have the option to waste a whole
-  // cacheline
-  unsigned long long addrOffset =
-      td->dumpRegisters
-          ? sizeof(DumpRegisterStruct) / sizeof(unsigned long long)
-          : 0;
-
 #if defined(linux) || defined(__linux__)
   pthread_setname_np(pthread_self(), "LoadWorker");
 #endif
@@ -278,23 +303,40 @@ void Firestarter::loadThreadWorker(std::shared_ptr<LoadWorkerData> td) {
       // for them.
       td->addrMem =
           reinterpret_cast<unsigned long long *>(ALIGNED_MALLOC(
-              (td->buffersizeMem + addrOffset) * sizeof(unsigned long long),
+              (td->buffersizeMem + td->addrOffset) * sizeof(unsigned long long),
               64)) +
-          addrOffset;
+          td->addrOffset;
 
       // exit application on error
-      if (td->addrMem - addrOffset == nullptr) {
-        workerLog::error() << "Could not allocate memory for CPU load thread";
+      if (td->addrMem - td->addrOffset == nullptr) {
+        workerLog::error() << "Could not allocate memory for CPU load thread "
+                           << td->id() << "\n";
         exit(ENOMEM);
       }
 
       if (td->dumpRegisters) {
-        reinterpret_cast<DumpRegisterStruct *>(td->addrMem - addrOffset)
+        reinterpret_cast<DumpRegisterStruct *>(td->addrMem - td->addrOffset)
             ->dumpVar = DumpVariable::Wait;
+      }
+
+      if (td->errorDetection) {
+        auto errorDetectionStruct = reinterpret_cast<ErrorDetectionStruct *>(
+            td->addrMem - td->addrOffset);
+
+        std::memset(errorDetectionStruct, 0, sizeof(ErrorDetectionStruct));
+
+        // distribute left and right communication pointers
+        errorDetectionStruct->communicationLeft = td->communicationLeft.get();
+        errorDetectionStruct->communicationRight = td->communicationRight.get();
+
+        // do first touch memset 0 for the communication pointers
+        std::memset((void *)errorDetectionStruct->communicationLeft, 0,
+                    sizeof(unsigned long long) * 2);
       }
 
       // call init function
       td->config().payload().init(td->addrMem, td->buffersizeMem);
+
       break;
     // perform stress test
     case THREAD_WORK:
@@ -335,7 +377,6 @@ void Firestarter::loadThreadWorker(std::shared_ptr<LoadWorkerData> td) {
         if (*td->addrHigh == LOAD_STOP) {
           td->stopTsc = td->environment().topology().timestamp();
 
-          ALIGNED_FREE(td->addrMem - addrOffset);
           return;
         }
 
@@ -367,7 +408,6 @@ void Firestarter::loadThreadWorker(std::shared_ptr<LoadWorkerData> td) {
       break;
     case THREAD_STOP:
     default:
-      ALIGNED_FREE(td->addrMem - addrOffset);
       return;
     }
   }

--- a/src/firestarter/Main.cpp
+++ b/src/firestarter/Main.cpp
@@ -211,7 +211,7 @@ Config::Config(int argc, const char **argv) {
     ("b,bind", "Select certain CPUs. CPULIST format: \"x,y,z\",\n\"x-y\", \"x-y/step\", and any combination of the\nabove. Cannot be combined with -n | --threads.",
       cxxopts::value<std::string>()->default_value(""), "CPULIST")
 #endif
-    ("error-detection", "Enable error detection. FIRESTARTER must run with 2 or more threads for this feature. Cannot be used with --dump-registers.");
+    ("error-detection", "Enable error detection. This aborts execution when the calculated data is corruped by errors. FIRESTARTER must run with 2 or more threads for this feature. Cannot be used with -l | --load and --optimize.");
 
   parser.add_options("specialized-workloads")
     ("list-instruction-groups", "List the available instruction groups for the\npayload of the current platform.")
@@ -412,6 +412,10 @@ Config::Config(int argc, const char **argv) {
     listMetrics = options.count("list-metrics");
 
     if ((optimize = options.count("optimize"))) {
+      if (errorDetection) {
+        throw std::invalid_argument("Options --error-detection and --optimize "
+                                    "cannot be used together.");
+      }
       if (measurement) {
         throw std::invalid_argument(
             "Options --measurement and --optimize cannot be used together.");

--- a/src/firestarter/Main.cpp
+++ b/src/firestarter/Main.cpp
@@ -330,10 +330,15 @@ Config::Config(int argc, const char **argv) {
       throw std::invalid_argument("Option -l/--load may not be above 100.");
     }
 
+    errorDetection = options.count("error-detection");
+    if (errorDetection && loadPercent != 100) {
+      throw std::invalid_argument("Option --error-detection may only be used "
+                                  "with -l/--load equal 100.");
+    }
+
 #ifdef FIRESTARTER_DEBUG_FEATURES
     allowUnavailablePayload = options.count("allow-unavailable-payload");
     dumpRegisters = options.count("dump-registers");
-    errorDetection = options.count("error-detection");
     if (dumpRegisters) {
       dumpRegistersTimeDelta =
           std::chrono::seconds(options["dump-registers"].as<unsigned>());

--- a/src/firestarter/Main.cpp
+++ b/src/firestarter/Main.cpp
@@ -168,7 +168,14 @@ Config::Config(int argc, const char **argv) {
 
   // clang-format off
   parser.add_options("information")
-    ("h,help", "Display usage information. SECTION can be any of: information | general | specialized-workloads | debug\n| measurement | optimization",
+    ("h,help", "Display usage information. SECTION can be any of: information | general | specialized-workloads"
+#ifdef FIRESTARTER_DEBUG_FEATURES
+     " | debug"
+#endif
+#if defined(linux) || defined(__linux__)
+     "\n| measurement | optimization"
+#endif
+     ,
       cxxopts::value<std::string>()->implicit_value(""), "SECTION")
     ("v,version", "Display version information")
     ("c,copyright", "Display copyright information")
@@ -204,7 +211,7 @@ Config::Config(int argc, const char **argv) {
     ("b,bind", "Select certain CPUs. CPULIST format: \"x,y,z\",\n\"x-y\", \"x-y/step\", and any combination of the\nabove. Cannot be combined with -n | --threads.",
       cxxopts::value<std::string>()->default_value(""), "CPULIST")
 #endif
-    ;
+    ("error-detection", "Enable error detection. FIRESTARTER must run with 2 or more threads for this feature. Cannot be used with --dump-registers.");
 
   parser.add_options("specialized-workloads")
     ("list-instruction-groups", "List the available instruction groups for the\npayload of the current platform.")
@@ -219,8 +226,7 @@ Config::Config(int argc, const char **argv) {
     ("dump-registers", "Dump the working registers on the first\nthread. Depending on the payload these are mm, xmm,\nymm or zmm. Only use it without a timeout and\n100 percent load. DELAY between dumps in secs. Cannot be used with --error-detection.",
       cxxopts::value<unsigned>()->implicit_value("10"), "DELAY")
     ("dump-registers-outpath", "Path for the dump of the output files. If\nPATH is not given, current working directory will\nbe used.",
-      cxxopts::value<std::string>()->default_value(""), "PATH")
-    ("error-detection", "Enable error detection. FIRESTARTER must run with 2 or more threads for this feature. Cannot be used with --dump-registers.");
+      cxxopts::value<std::string>()->default_value(""), "PATH");
 #endif
 
 #if defined(linux) || defined(__linux__)


### PR DESCRIPTION
FIRESTARTER computes the same work on multiple threads. By checking if the registers on all threads contain the same data at the same point of execution allows us to check if errors occurred in the hardware.
If this check fails, we stop the execution of FIRESTARTER and give an error like this one:
```
Fatal: Data mismatch between Threads 0 and 1.
       This may be caused by bit-flips in the hardware.
```

The option is enabled by setting the command-line flag `--error-detection`.