### PR TITLE
Option to minimize metric values in the optimization.

### DIFF
--- a/include/firestarter/Optimizer/History.hpp
+++ b/include/firestarter/Optimizer/History.hpp
@@ -116,6 +116,15 @@ public:
                                          SummaryMap const &mapB) {
         auto summaryA = mapA.find(metric);
         auto summaryB = mapB.find(metric);
+
+        if (summaryA == mapA.end() || summaryB == mapB.end()) {
+          summaryA = mapA.find(metric.substr(1));
+          summaryB = mapB.find(metric.substr(1));
+          assert(summaryA != mapA.end());
+          assert(summaryB != mapB.end());
+          return summaryA->second.average < summaryB->second.average;
+        }
+
         assert(summaryA != mapA.end());
         assert(summaryB != mapB.end());
         return summaryA->second.average > summaryB->second.average;
@@ -181,8 +190,8 @@ public:
 
       std::stringstream ss;
 
-      ss << "\n Best individuals sorted by metric " << metric
-         << " descending:\n"
+      ss << "\n Best individuals sorted by metric " << metric << " "
+         << ((metric[0] == '-') ? "ascending" : "descending") << ":\n"
          << firstLine.str() << "\n"
          << secondLine.str() << "\n";
 
@@ -196,9 +205,19 @@ public:
 
         for (auto const &metric : optimizationMetrics) {
           auto width = columnWidth[metric];
+          std::string value;
+
           auto fitnessOfMetric = fitness.find(metric);
-          assert(fitnessOfMetric != fitness.end());
-          auto value = std::to_string(fitnessOfMetric->second.average);
+          auto invertedMetric = metric.substr(1);
+          auto fitnessOfInvertedMetric = fitness.find(invertedMetric);
+
+          if (fitnessOfMetric != fitness.end()) {
+            value = std::to_string(fitnessOfMetric->second.average);
+          } else if (fitnessOfInvertedMetric != fitness.end()) {
+            value = std::to_string(fitnessOfInvertedMetric->second.average);
+          } else {
+            assert(false);
+          }
 
           ss << " | " << value;
           padding(ss, width, value.size(), ' ');

--- a/include/firestarter/Optimizer/Problem/CLIArgumentProblem.hpp
+++ b/include/firestarter/Optimizer/Problem/CLIArgumentProblem.hpp
@@ -94,7 +94,9 @@ public:
 
     for (auto const &metricName : _metrics) {
       auto findName = [metricName](auto const &summary) {
-        return metricName.compare(summary.first) == 0;
+        auto invertedName = "-" + summary.first;
+        return metricName.compare(summary.first) == 0 ||
+               metricName.compare(invertedName) == 0;
       };
 
       auto it = std::find_if(summaries.begin(), summaries.end(), findName);
@@ -105,6 +107,12 @@ public:
 
       // round to two decimal places after the comma
       auto value = std::round(it->second.average * 100.0) / 100.0;
+
+      // invert metric
+      if (metricName[0] == '-') {
+        value *= -1.0;
+      }
+
       values.push_back(value);
     }
 

--- a/src/firestarter/Firestarter.cpp
+++ b/src/firestarter/Firestarter.cpp
@@ -153,7 +153,9 @@ Firestarter::Firestarter(
     // check if selected metrics are initialized
     for (auto const &optimizationMetric : optimizationMetrics) {
       auto nameEqual = [optimizationMetric](auto const &name) {
-        return name.compare(optimizationMetric) == 0;
+        auto invertedName = "-" + name;
+        return name.compare(optimizationMetric) == 0 ||
+               invertedName.compare(optimizationMetric) == 0;
       };
       // metric name is not found
       if (std::find_if(all.begin(), all.end(), nameEqual) == all.end()) {
@@ -353,12 +355,12 @@ void Firestarter::mainThread() {
 
     auto payloadItems = this->environment().selectedConfig().payloadItems();
 
+    firestarter::optimizer::History::save(_optimizeOutfile, startTime,
+                                          payloadItems, _argc, _argv);
+
     // print the best 20 according to each metric
     firestarter::optimizer::History::printBest(_optimizationMetrics,
                                                payloadItems);
-
-    firestarter::optimizer::History::save(_optimizeOutfile, startTime,
-                                          payloadItems, _argc, _argv);
 
     // stop all the load threads
     std::raise(SIGTERM);


### PR DESCRIPTION
This PR allows the user to set a "minus" before a metric name in the `--optimization-metric` parameter, to select minimization (default: maximization) of this metric.

Example: `FIRESTARTER --optimize NSGA2 --optimization-metric sysfs-powercap-rapl,perf-ipc,-perf-freq`