### PR TITLE
Changes to support the NVHPC SDK

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -59,9 +59,6 @@ jobs:
             export NVHPC_INSTALL_DIR="${CUDA_ROOT}"
             export NVHPC_INSTALL_TYPE="single"
             sudo ./nvhpc_2022_225_Linux_x86_64_cuda_11.7/install
-            NVARCH=`uname -s`_`uname -m`; export NVARCH
-            MANPATH=$MANPATH:$CUDA_ROOT/$NVARCH/22.5/compilers/man; export MANPATH
-            PATH=$CUDA_ROOT/$NVARCH/22.5/compilers/bin:$PATH; export PATH
         esac
     - name: Create build directory
       run: |
@@ -74,7 +71,7 @@ jobs:
         cd build
         cmake ..
     - name: Run CMake configure
-      if: matrix.CUDA != '0'
+      if: matrix.CUDA != '0' && matrix.CUDA != 'NVHPC-22.5'
       env:
         CXX: ${{ matrix.compiler }}
       run: |
@@ -89,6 +86,15 @@ jobs:
 
         cd build
         cmake -DFIRESTARTER_BUILD_TYPE="FIRESTARTER_CUDA" -DCMAKE_EXE_LINKER_FLAGS="-L${CUDA_ROOT}/lib64/stubs/" ..
+      if: matrix.CUDA == 'NVHPC-22.5'
+      env:
+        CXX: ${{ matrix.compiler }}
+      run: |
+        NVARCH=`uname -s`_`uname -m`; export NVARCH
+        PATH=$CUDA_ROOT/$NVARCH/22.5/compilers/bin:$PATH; export PATH
+
+        cd build
+        cmake -DFIRESTARTER_BUILD_TYPE="FIRESTARTER_CUDA" ..
     - name: Build
       run: |
         cd build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,4 +1,4 @@
-nnvhpc_2022_225_Linux_x86_64_cuda_11.7.tar.gzame: Build
+name: Build
 
 on: [push, pull_request]
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -10,8 +10,8 @@ jobs:
         os: [ubuntu-20.04]
           #compiler: [g++-7, g++-8, g++-9, g++-10, clang++-8, clang++-9, clang++-10]
         compiler: [g++-10, clang++-10]
-          #CUDA: ['0', '8.0', '11.0', 'NVHPC-22.5']
-        CUDA: ['0', 'NVHPC-22.5']
+          CUDA: ['0', '8.0', '11.0', 'NVHPC-22.5']
+          #CUDA: ['0', 'NVHPC-22.5']
           #CUDA: ['0', '8.0', '11.0']
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -86,6 +86,7 @@ jobs:
 
         cd build
         cmake -DFIRESTARTER_BUILD_TYPE="FIRESTARTER_CUDA" -DCMAKE_EXE_LINKER_FLAGS="-L${CUDA_ROOT}/lib64/stubs/" ..
+    - name: Run CMake configure
       if: matrix.CUDA == 'NVHPC-22.5'
       env:
         CXX: ${{ matrix.compiler }}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -10,7 +10,7 @@ jobs:
         os: [ubuntu-20.04]
           #compiler: [g++-7, g++-8, g++-9, g++-10, clang++-8, clang++-9, clang++-10]
         compiler: [g++-10, clang++-10]
-          CUDA: ['0', '8.0', '11.0', 'NVHPC-22.5']
+        CUDA: ['0', '8.0', '11.0', 'NVHPC-22.5']
           #CUDA: ['0', 'NVHPC-22.5']
           #CUDA: ['0', '8.0', '11.0']
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,4 +1,4 @@
-name: Build
+nnvhpc_2022_225_Linux_x86_64_cuda_11.7.tar.gzame: Build
 
 on: [push, pull_request]
 
@@ -8,9 +8,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04]
-        compiler: [g++-7, g++-8, g++-9, g++-10, clang++-8, clang++-9, clang++-10]
+          #compiler: [g++-7, g++-8, g++-9, g++-10, clang++-8, clang++-9, clang++-10]
+        compiler: [g++-7]
           #CUDA: ['0', '8.0', '11.0', 'NVHPC-22.5']
-        CUDA: ['0', '8.0', '11.0']
+          #CUDA: ['0', '8.0', '11.0']
+        CUDA: ['0', '8.0']
 
     runs-on: ${{ matrix.os }}
 
@@ -307,6 +309,7 @@ jobs:
     - name: Move binary to right directory
       run: |
         mv FIRESTARTER/FIRESTARTER.exe FIRESTARTER-windows.exe
+        mv FIRESTARTER/libhwloc-15.dll libhwloc-15.dll
         rm -rf FIRESTARTER
     # Create tar.gz
     - name: Copy CHANGELOG, README and LICENSE

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -103,8 +103,7 @@ jobs:
         LD_LIBRARY_PATH=$CUDA_ROOT/$NVARCH/22.5/cuda/11.7/lib64/stubs:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH
 
         cd build
-        #cmake -DFIRESTARTER_BUILD_TYPE="FIRESTARTER_CUDA" -DCMAKE_EXE_LINKER_FLAGS="-L${CUDA_ROOT}/$NVARCH/22.5/compilers/lib" -LA ..
-        cmake -DFIRESTARTER_BUILD_TYPE="FIRESTARTER_CUDA" -LA ..
+        cmake -DFIRESTARTER_BUILD_TYPE="FIRESTARTER_CUDA" -DCMAKE_EXE_LINKER_FLAGS=-L"$CUDA_ROOT/$NVARCH/22.5/cuda/11.7/lib64/stubs" -LA ..
     - name: Build
       run: |
         cd build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         compiler: [g++-7, g++-8, g++-9, g++-10, clang++-8, clang++-9, clang++-10]
-        CUDA: ['0', '6.5', '8.0', '11.0']
+        CUDA: ['0', '8.0', '11.0']
 
     runs-on: ${{ matrix.os }}
 
@@ -40,11 +40,6 @@ jobs:
       if: matrix.CUDA != '0'
       run: |
         case ${{ matrix.CUDA }} in
-          6.5)
-            wget http://developer.download.nvidia.com/compute/cuda/6_5/rel/installers/cuda_6.5.14_linux_64.run
-            sudo sh cuda_6.5.14_linux_64.run -extract=${CUDA_ROOT}
-            sudo sh ${CUDA_ROOT}/cuda-linux64-rel-6.5.14-18749181.run --tar mxvf -C ${CUDA_ROOT}
-            ;;
           8.0)
             wget https://developer.nvidia.com/compute/cuda/8.0/Prod2/local_installers/cuda_8.0.61_375.26_linux-run
             wget https://developer.nvidia.com/compute/cuda/8.0/Prod2/patches/2/cuda_8.0.61.2_linux-run
@@ -269,17 +264,6 @@ jobs:
         mv FIRESTARTER/FIRESTARTER FIRESTARTER-linux
         rm -rf FIRESTARTER
         chmod +x FIRESTARTER-linux
-    # Linux CUDA 6.5
-    - name: Retrieve FIRESTARTER_CUDA_6.5-linux 
-      uses: actions/download-artifact@v2
-      with:
-        name: FIRESTARTER_CUDA_6.5-linux
-        path: FIRESTARTER
-    - name: Move binary to right directory
-      run: |
-        mv FIRESTARTER/FIRESTARTER_CUDA FIRESTARTER_CUDA_6.5
-        rm -rf FIRESTARTER
-        chmod +x FIRESTARTER_CUDA_6.5
     # Linux CUDA 8.0
     - name: Retrieve FIRESTARTER_CUDA_8.0-linux 
       uses: actions/download-artifact@v2

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -9,8 +9,8 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         compiler: [g++-7, g++-8, g++-9, g++-10, clang++-8, clang++-9, clang++-10]
-          #CUDA: ['0', '8.0', '11.0', 'NVHPC-22.5']
-        CUDA: ['0', '8.0', '11.0']
+        CUDA: ['0', '8.0', '11.0', 'NVHPC-22.5']
+          #CUDA: ['0', '8.0', '11.0']
 
     runs-on: ${{ matrix.os }}
 
@@ -59,6 +59,9 @@ jobs:
             export NVHPC_INSTALL_DIR="${CUDA_ROOT}"
             export NVHPC_INSTALL_TYPE="single"
             sudo ./nvhpc_2022_225_Linux_x86_64_cuda_11.7/install
+            NVARCH=`uname -s`_`uname -m`; export NVARCH
+            MANPATH=$MANPATH:$CUDA_ROOT/$NVARCH/22.5/compilers/man; export MANPATH
+            PATH=$CUDA_ROOT/$NVARCH/22.5/compilers/bin:$PATH; export PATH
         esac
     - name: Create build directory
       run: |
@@ -163,6 +166,12 @@ jobs:
     - name: Copy Hwloc DLL
       shell: pwsh
       if: matrix.cfg.MSVC == true
+      run: |
+        cd build
+        cp ../lib/Hwloc/sources/contrib/windows/x64/Release/libhwloc-15.dll src
+    - name: Copy Hwloc DLL
+      shell: pwsh
+      if: matrix.cfg.MSVC == false
       run: |
         cd build
         cp ../lib/Hwloc/sources/contrib/windows/x64/Release/libhwloc-15.dll src

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -8,11 +8,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04]
-          #compiler: [g++-7, g++-8, g++-9, g++-10, clang++-8, clang++-9, clang++-10]
-        compiler: [g++-7]
+        compiler: [g++-7, g++-8, g++-9, g++-10, clang++-8, clang++-9, clang++-10]
           #CUDA: ['0', '8.0', '11.0', 'NVHPC-22.5']
-          #CUDA: ['0', '8.0', '11.0']
-        CUDA: ['0', '8.0']
+        CUDA: ['0', '8.0', '11.0']
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -79,7 +79,7 @@ jobs:
         export PATH=${CUDA_ROOT}:${PATH}
         export CUDA_HOME=${CUDA_ROOT}
         export CUDA_PATH=${CUDA_ROOT}
-        export CUDA_TOOLKIT_ROOT_DIR=${CUDA_ROOT}
+        export CUDAToolkit_ROOT=${CUDA_ROOT}
 
         cd build
         cmake -DFIRESTARTER_BUILD_TYPE="FIRESTARTER_CUDA" -DCMAKE_EXE_LINKER_FLAGS="-L${CUDA_ROOT}/lib64/stubs/" ..
@@ -164,7 +164,7 @@ jobs:
       shell: pwsh
       run: |
         cd build
-        cmake -G "NMake Makefiles" -DFIRESTARTER_BUILD_TYPE="FIRESTARTER_CUDA" -DCUDA_TOOLKIT_ROOT_DIR="C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v11.0" ..
+        cmake -G "NMake Makefiles" -DFIRESTARTER_BUILD_TYPE="FIRESTARTER_CUDA" -DCUDAToolkit_ROOT="C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v11.0" ..
     - name: Build
       shell: pwsh
       run: |

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -57,12 +57,15 @@ jobs:
           NVHPC-22.5)
             wget https://developer.download.nvidia.com/hpc-sdk/22.5/nvhpc_2022_225_Linux_x86_64_cuda_11.7.tar.gz
             tar xpzf nvhpc_2022_225_Linux_x86_64_cuda_11.7.tar.gz
-            export NVHPC_SILENT="true"
-            export NVHPC_INSTALL_DIR="${CUDA_ROOT}"
-            export NVHPC_INSTALL_TYPE="single"
+            sudo export NVHPC_SILENT="true"
+            sudo export NVHPC_INSTALL_DIR="${CUDA_ROOT}"
+            sodo export NVHPC_INSTALL_TYPE="single"
             echo $NVHPC_SILENT
             echo $NVHPC_INSTALL_DIR
             echo $NVHPC_INSTALL_TYPE
+            sudo echo $NVHPC_SILENT
+            sudo echo $NVHPC_INSTALL_DIR
+            sudo echo $NVHPC_INSTALL_TYPE
             sudo ./nvhpc_2022_225_Linux_x86_64_cuda_11.7/install
         esac
     - name: Create build directory

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -99,9 +99,12 @@ jobs:
         NVARCH=`uname -s`_`uname -m`; export NVARCH
         PATH=$CUDA_ROOT/$NVARCH/22.5/compilers/bin:$PATH; export PATH
         LD_LIBRARY_PATH=$CUDA_ROOT/$NVARCH/22.5/compilers/lib:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH
+        LD_LIBRARY_PATH=$CUDA_ROOT/$NVARCH/22.5/cuda/11.7/lib64:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH
+        LD_LIBRARY_PATH=$CUDA_ROOT/$NVARCH/22.5/cuda/11.7/lib64/stubs:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH
 
         cd build
-        cmake -DFIRESTARTER_BUILD_TYPE="FIRESTARTER_CUDA" -DCMAKE_EXE_LINKER_FLAGS="-L${CUDA_ROOT}/$NVARCH/22.5/compilers/lib" -LA ..
+        #cmake -DFIRESTARTER_BUILD_TYPE="FIRESTARTER_CUDA" -DCMAKE_EXE_LINKER_FLAGS="-L${CUDA_ROOT}/$NVARCH/22.5/compilers/lib" -LA ..
+        cmake -DFIRESTARTER_BUILD_TYPE="FIRESTARTER_CUDA" -LA ..
     - name: Build
       run: |
         cd build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -57,12 +57,6 @@ jobs:
           NVHPC-22.5)
             wget https://developer.download.nvidia.com/hpc-sdk/22.5/nvhpc_2022_225_Linux_x86_64_cuda_11.7.tar.gz
             tar xpzf nvhpc_2022_225_Linux_x86_64_cuda_11.7.tar.gz
-            export NVHPC_SILENT="true"
-            export NVHPC_INSTALL_DIR="${CUDA_ROOT}"
-            export NVHPC_INSTALL_TYPE="single"
-            echo $NVHPC_SILENT
-            echo $NVHPC_INSTALL_DIR
-            echo $NVHPC_INSTALL_TYPE
             sudo NVHPC_SILENT="true" NVHPC_INSTALL_DIR="$CUDA_ROOT" NVHPC_INSTALL_TYPE="single" ./nvhpc_2022_225_Linux_x86_64_cuda_11.7/install
         esac
     - name: Create build directory

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -101,7 +101,7 @@ jobs:
         LD_LIBRARY_PATH=$CUDA_ROOT/$NVARCH/22.5/compilers/lib:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH
 
         cd build
-        cmake -DFIRESTARTER_BUILD_TYPE="FIRESTARTER_CUDA" -LA ..
+        cmake -DFIRESTARTER_BUILD_TYPE="FIRESTARTER_CUDA" -DCMAKE_EXE_LINKER_FLAGS="-L${CUDA_ROOT}/$NVARCH/22.5/compilers/lib" -LA ..
     - name: Build
       run: |
         cd build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -57,16 +57,13 @@ jobs:
           NVHPC-22.5)
             wget https://developer.download.nvidia.com/hpc-sdk/22.5/nvhpc_2022_225_Linux_x86_64_cuda_11.7.tar.gz
             tar xpzf nvhpc_2022_225_Linux_x86_64_cuda_11.7.tar.gz
-            sudo export NVHPC_SILENT="true"
-            sudo export NVHPC_INSTALL_DIR="${CUDA_ROOT}"
-            sodo export NVHPC_INSTALL_TYPE="single"
+            export NVHPC_SILENT="true"
+            export NVHPC_INSTALL_DIR="${CUDA_ROOT}"
+            export NVHPC_INSTALL_TYPE="single"
             echo $NVHPC_SILENT
             echo $NVHPC_INSTALL_DIR
             echo $NVHPC_INSTALL_TYPE
-            sudo echo $NVHPC_SILENT
-            sudo echo $NVHPC_INSTALL_DIR
-            sudo echo $NVHPC_INSTALL_TYPE
-            sudo ./nvhpc_2022_225_Linux_x86_64_cuda_11.7/install
+            sudo NVHPC_SILENT="true" NVHPC_INSTALL_DIR="$CUDA_ROOT" NVHPC_INSTALL_TYPE="single" ./nvhpc_2022_225_Linux_x86_64_cuda_11.7/install
         esac
     - name: Create build directory
       run: |

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         compiler: [g++-7, g++-8, g++-9, g++-10, clang++-8, clang++-9, clang++-10]
-        CUDA: ['0', '8.0', '11.0']
+        CUDA: ['0', '8.0', '11.0', 'NVHPC-22.5']
 
     runs-on: ${{ matrix.os }}
 
@@ -51,6 +51,13 @@ jobs:
             wget https://developer.download.nvidia.com/compute/cuda/11.0.3/local_installers/cuda_11.0.3_450.51.06_linux.run
             sudo sh cuda_11.0.3_450.51.06_linux.run --toolkit --toolkitpath=${CUDA_ROOT} --override --silent
             ;;
+          NVHPC-22.5)
+            wget https://developer.download.nvidia.com/hpc-sdk/22.5/nvhpc_2022_225_Linux_x86_64_cuda_11.7.tar.gz
+            tar xpzf nvhpc_2022_225_Linux_x86_64_cuda_11.7.tar.gz
+            export NVHPC_SILENT="true"
+            export NVHPC_INSTALL_DIR="${CUDA_ROOT}"
+            export NVHPC_INSTALL_TYPE="single"
+            sudo ./nvhpc_2022_225_Linux_x86_64_cuda_11.7/install
         esac
     - name: Create build directory
       run: |
@@ -171,7 +178,9 @@ jobs:
       if: matrix.cfg.CUDA == '0' && matrix.cfg.MSVC == false
       with:
         name: FIRESTARTER-windows
-        path: build\src\FIRESTARTER.exe
+        path: |
+          build\src\FIRESTARTER.exe
+          build\src\libhwloc-15.dll
   build-macos:
     strategy:
       fail-fast: false

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -9,7 +9,8 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         compiler: [g++-7, g++-8, g++-9, g++-10, clang++-8, clang++-9, clang++-10]
-        CUDA: ['0', '8.0', '11.0', 'NVHPC-22.5']
+          #CUDA: ['0', '8.0', '11.0', 'NVHPC-22.5']
+        CUDA: ['0', '8.0', '11.0']
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -178,12 +178,6 @@ jobs:
       run: |
         cd build
         cp ../lib/Hwloc/sources/contrib/windows/x64/Release/libhwloc-15.dll src
-    - name: Copy Hwloc DLL
-      shell: pwsh
-      if: matrix.cfg.MSVC == false
-      run: |
-        cd build
-        cp ../lib/Hwloc/sources/contrib/windows/x64/Release/libhwloc-15.dll src
     - name: Strip binary
       if: matrix.cfg.CUDA == '0' && matrix.cfg.MSVC == false
       run: |
@@ -195,6 +189,13 @@ jobs:
       run: .\build\src\FIRESTARTER.exe -t 1
     - uses: actions/upload-artifact@v2
       if: matrix.cfg.CUDA == '0' && matrix.cfg.MSVC == false
+      with:
+        name: FIRESTARTER-windows
+        path: |
+          build\src\FIRESTARTER.exe
+          build\src\libhwloc-15.dll
+    - uses: actions/upload-artifact@v2
+      if: matrix.cfg.CUDA == '0' && matrix.cfg.MSVC == true
       with:
         name: FIRESTARTER-windows
         path: |

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -9,9 +9,9 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
           #compiler: [g++-7, g++-8, g++-9, g++-10, clang++-8, clang++-9, clang++-10]
-        compiler: [g++-10]
+        compiler: [g++-10, clang++-10]
           #CUDA: ['0', '8.0', '11.0', 'NVHPC-22.5']
-        CUDA: ['NVHPC-22.5']
+        CUDA: ['0', 'NVHPC-22.5']
           #CUDA: ['0', '8.0', '11.0']
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -98,9 +98,10 @@ jobs:
       run: |
         NVARCH=`uname -s`_`uname -m`; export NVARCH
         PATH=$CUDA_ROOT/$NVARCH/22.5/compilers/bin:$PATH; export PATH
+        LD_LIBRARY_PATH=$CUDA_ROOT/$NVARCH/22.5/compilers/lib:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH
 
         cd build
-        cmake -DFIRESTARTER_BUILD_TYPE="FIRESTARTER_CUDA" ..
+        cmake -DFIRESTARTER_BUILD_TYPE="FIRESTARTER_CUDA" -LA ..
     - name: Build
       run: |
         cd build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -8,8 +8,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04]
-        compiler: [g++-7, g++-8, g++-9, g++-10, clang++-8, clang++-9, clang++-10]
-        CUDA: ['0', '8.0', '11.0', 'NVHPC-22.5']
+          #compiler: [g++-7, g++-8, g++-9, g++-10, clang++-8, clang++-9, clang++-10]
+        compiler: [g++-10]
+          #CUDA: ['0', '8.0', '11.0', 'NVHPC-22.5']
+        CUDA: ['NVHPC-22.5']
           #CUDA: ['0', '8.0', '11.0']
 
     runs-on: ${{ matrix.os }}
@@ -58,6 +60,9 @@ jobs:
             export NVHPC_SILENT="true"
             export NVHPC_INSTALL_DIR="${CUDA_ROOT}"
             export NVHPC_INSTALL_TYPE="single"
+            echo $NVHPC_SILENT
+            echo $NVHPC_INSTALL_DIR
+            echo $NVHPC_INSTALL_TYPE
             sudo ./nvhpc_2022_225_Linux_x86_64_cuda_11.7/install
         esac
     - name: Create build directory

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -113,7 +113,6 @@ jobs:
         cfg:
           - { CUDA: '0', MSVC: true }
           - { CUDA: '0', MSVC: false }
-          - { CUDA: '11.0', MSVC: true }
 
     runs-on: ${{ matrix.os }}
 
@@ -130,12 +129,6 @@ jobs:
       if: matrix.cfg.MSVC == false
       with:
         args: install mingw
-    - name: Install CUDA Toolkit
-      if: matrix.cfg.CUDA == '11.0'
-      shell: pwsh
-      run: |
-        Set-ExecutionPolicy unrestricted
-        & '.github\\install-cuda.ps1' -Version '11.0'
     - uses: ilammy/msvc-dev-cmd@v1
       if: matrix.cfg.MSVC == true
     - name: Create build directory
@@ -154,12 +147,6 @@ jobs:
       run: |
         cd build
         cmake -G "NMake Makefiles" ..
-    - name: Run CMake configure
-      if: matrix.cfg.CUDA != '0'
-      shell: pwsh
-      run: |
-        cd build
-        cmake -G "NMake Makefiles" -DFIRESTARTER_BUILD_TYPE="FIRESTARTER_CUDA" -DCUDAToolkit_ROOT="C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v11.0" ..
     - name: Build
       shell: pwsh
       run: |
@@ -185,13 +172,6 @@ jobs:
       with:
         name: FIRESTARTER-windows
         path: build\src\FIRESTARTER.exe
-    - uses: actions/upload-artifact@v2
-      if: matrix.cfg.CUDA != '0'
-      with:
-        name: FIRESTARTER_CUDA_${{ matrix.cfg.CUDA }}-windows
-        path: |
-          build\src\FIRESTARTER_CUDA.exe
-          build\src\libhwloc-15.dll
   build-macos:
     strategy:
       fail-fast: false
@@ -317,17 +297,6 @@ jobs:
     - name: Move binary to right directory
       run: |
         mv FIRESTARTER/FIRESTARTER.exe FIRESTARTER-windows.exe
-        rm -rf FIRESTARTER
-    # Windows CUDA 11.0
-    - name: Retrieve FIRESTARTER_CUDA_11.0-windows
-      uses: actions/download-artifact@v2
-      with:
-        name: FIRESTARTER_CUDA_11.0-windows
-        path: FIRESTARTER
-    - name: Move binary to right directory
-      run: |
-        mv FIRESTARTER/FIRESTARTER_CUDA.exe FIRESTARTER_CUDA_11.0-windows.exe
-        mv FIRESTARTER/libhwloc-15.dll libhwloc-15.dll
         rm -rf FIRESTARTER
     # Create tar.gz
     - name: Copy CHANGELOG, README and LICENSE

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -8,11 +8,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04]
-          #compiler: [g++-7, g++-8, g++-9, g++-10, clang++-8, clang++-9, clang++-10]
-        compiler: [g++-10, clang++-10]
+        compiler: [g++-7, g++-8, g++-9, g++-10, clang++-8, clang++-9, clang++-10]
         CUDA: ['0', '8.0', '11.0', 'NVHPC-22.5']
-          #CUDA: ['0', 'NVHPC-22.5']
-          #CUDA: ['0', '8.0', '11.0']
 
     runs-on: ${{ matrix.os }}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.22)
 project(FIRESTARTER)
 
 include(cmake/GitSubmoduleUpdate.cmake)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,7 +49,7 @@ if (FIRESTARTER_THREAD_AFFINITY)
 endif()
 
 if ("${FIRESTARTER_BUILD_TYPE}" STREQUAL "FIRESTARTER_CUDA")
-	find_package(CUDA REQUIRED)
+	find_package(CUDAToolkit REQUIRED)
 	include_directories(${CUDA_INCLUDE_DIRS})
 
 	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DFIRESTARTER_BUILD_CUDA")
@@ -72,9 +72,11 @@ if ("${FIRESTARTER_BUILD_TYPE}" STREQUAL "FIRESTARTER_CUDA")
 		Nitro::log
 		nlohmann_json::nlohmann_json
 		Threads::Threads
-		${CUDA_LIBRARIES}
-		${CUDA_CUBLAS_LIBRARIES}
-		${CUDA_curand_LIBRARY}
+                CUDA::cuda_driver
+                CUDA::cudart
+                CUDA::cufft
+                CUDA::curand
+                CUDA::cublas
 		)
 
 	if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
@@ -88,7 +90,7 @@ if ("${FIRESTARTER_BUILD_TYPE}" STREQUAL "FIRESTARTER_CUDA")
 			)
 	endif()
 elseif(${FIRESTARTER_BUILD_TYPE} STREQUAL "FIRESTARTER_CUDA_ONLY")
-	find_package(CUDA REQUIRED)
+	find_package(CUDAToolkit REQUIRED)
 	include_directories(${CUDA_INCLUDE_DIRS})
 
 	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DFIRESTARTER_BUILD_CUDA -DFIRESTARTER_BUILD_CUDA_ONLY")
@@ -103,9 +105,11 @@ elseif(${FIRESTARTER_BUILD_TYPE} STREQUAL "FIRESTARTER_CUDA_ONLY")
 	target_link_libraries(FIRESTARTER_CUDA_ONLY
 		Nitro::log
 		Threads::Threads
-		${CUDA_LIBRARIES}
-		${CUDA_CUBLAS_LIBRARIES}
-		${CUDA_curand_LIBRARY}
+                CUDA::cuda_driver
+                CUDA::cudart
+                CUDA::cufft
+                CUDA::curand
+                CUDA::cublas
 		)
 
 	if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -72,11 +72,11 @@ if ("${FIRESTARTER_BUILD_TYPE}" STREQUAL "FIRESTARTER_CUDA")
 		Nitro::log
 		nlohmann_json::nlohmann_json
 		Threads::Threads
-                CUDA::cuda_driver
-                CUDA::cudart
-                CUDA::cufft
-                CUDA::curand
-                CUDA::cublas
+		CUDA::cuda_driver
+		CUDA::cudart
+		CUDA::cufft
+		CUDA::curand
+		CUDA::cublas
 		)
 
 	if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
@@ -105,11 +105,11 @@ elseif(${FIRESTARTER_BUILD_TYPE} STREQUAL "FIRESTARTER_CUDA_ONLY")
 	target_link_libraries(FIRESTARTER_CUDA_ONLY
 		Nitro::log
 		Threads::Threads
-                CUDA::cuda_driver
-                CUDA::cudart
-                CUDA::cufft
-                CUDA::curand
-                CUDA::cublas
+		CUDA::cuda_driver
+		CUDA::cudart
+		CUDA::cufft
+		CUDA::curand
+		CUDA::cublas
 		)
 
 	if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,7 +50,7 @@ endif()
 
 if ("${FIRESTARTER_BUILD_TYPE}" STREQUAL "FIRESTARTER_CUDA")
 	find_package(CUDAToolkit REQUIRED)
-	include_directories(${CUDA_INCLUDE_DIRS})
+	include_directories(${CUDAToolkit_INCLUDE_DIRS})
 
 	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DFIRESTARTER_BUILD_CUDA")
 
@@ -81,7 +81,7 @@ if ("${FIRESTARTER_BUILD_TYPE}" STREQUAL "FIRESTARTER_CUDA")
 
 	if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 		target_link_libraries(FIRESTARTER_CUDA
-			${CUDA_TOOLKIT_ROOT_DIR}/lib/x64/cuda.lib 
+                    ${CUDAToolkit_LIBRARY_ROOT}/lib/x64/cuda.lib 
 			)
 	else()
 		target_link_libraries(FIRESTARTER_CUDA
@@ -91,7 +91,7 @@ if ("${FIRESTARTER_BUILD_TYPE}" STREQUAL "FIRESTARTER_CUDA")
 	endif()
 elseif(${FIRESTARTER_BUILD_TYPE} STREQUAL "FIRESTARTER_CUDA_ONLY")
 	find_package(CUDAToolkit REQUIRED)
-	include_directories(${CUDA_INCLUDE_DIRS})
+	include_directories(${CUDAToolkit_INCLUDE_DIRS})
 
 	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DFIRESTARTER_BUILD_CUDA -DFIRESTARTER_BUILD_CUDA_ONLY")
 
@@ -114,7 +114,7 @@ elseif(${FIRESTARTER_BUILD_TYPE} STREQUAL "FIRESTARTER_CUDA_ONLY")
 
 	if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 		target_link_libraries(FIRESTARTER_CUDA_ONLY
-			${CUDA_TOOLKIT_ROOT_DIR}/lib/x64/cuda.lib
+                    ${CUDAToolkit_LIBRARY_ROOT}/lib/x64/cuda.lib
 			)
 	else()
 		target_link_libraries(FIRESTARTER_CUDA_ONLY


### PR DESCRIPTION
This fixes issue #45. The `findCUDAToolkit` module replaces the deprecated `findCUDA` module and is able to locate all CUDA libraries shipped with either CUDA or NVHPC. Dependencies such as cuBLAS are imported via imported targets.
CMake 3.22 is required as earlier version cannot find libraries when using CUDA + libraries provided by NVHPC.