### PR TITLE
Fix thread affinity/detected number of threads with some disabled in a cgroup.

### DIFF
--- a/include/firestarter/Environment/CPUTopology.hpp
+++ b/include/firestarter/Environment/CPUTopology.hpp
@@ -44,9 +44,8 @@ public:
 
   /// The total number of hardware threads.
   [[nodiscard]] auto numThreads() const -> unsigned { return NumThreadsPerCore * NumCoresTotal; }
-  /// The maximum os_index of all PUs plus 1 if we cannot determine the number of cpu kinds. Otherwise the maximum
-  /// number of PUs.
-  [[nodiscard]] auto maxNumThreads() const -> unsigned;
+  /// The hightest physical index in the hwloc cpuset.
+  [[nodiscard]] auto highestPhysicalIndex() const -> unsigned;
   /// Assuming we have a consistent number of threads per core. The number of thread per core.
   [[nodiscard]] auto numThreadsPerCore() const -> unsigned { return NumThreadsPerCore; }
   /// The total number of cores.

--- a/include/firestarter/Environment/CPUTopology.hpp
+++ b/include/firestarter/Environment/CPUTopology.hpp
@@ -34,6 +34,15 @@ extern "C" {
 
 namespace firestarter::environment {
 
+/// This struct describes properties of the threads which are used in the Environment class to assign a specific number
+/// of threads and/or use it for cpu binding.
+struct HardwareThreadsInfo {
+  /// The number of hardware threads on this system.
+  unsigned MaxNumThreads;
+  /// The highest physical index on a hardware thread in the system.
+  unsigned MaxPhysicalIndex;
+};
+
 /// This class models the properties of a processor.
 class CPUTopology {
 public:
@@ -42,33 +51,17 @@ public:
 
   friend auto operator<<(std::ostream& Stream, CPUTopology const& CpuTopologyRef) -> std::ostream&;
 
-  /// The total number of hardware threads.
-  [[nodiscard]] auto numThreads() const -> unsigned { return NumThreadsPerCore * NumCoresTotal; }
-  /// The hightest physical index in the hwloc cpuset.
-  [[nodiscard]] auto highestPhysicalIndex() const -> unsigned;
   /// Assuming we have a consistent number of threads per core. The number of thread per core.
   [[nodiscard]] auto numThreadsPerCore() const -> unsigned { return NumThreadsPerCore; }
-  /// The total number of cores.
-  [[nodiscard]] auto numCoresTotal() const -> unsigned { return NumCoresTotal; }
-  /// The total number of packages.
-  [[nodiscard]] auto numPackages() const -> unsigned { return NumPackages; }
-  /// The CPU architecture e.g., x86_64
-  [[nodiscard]] auto architecture() const -> std::string const& { return Architecture; }
-  /// The CPU vendor i.e., Intel or AMD.
-  [[nodiscard]] virtual auto vendor() const -> std::string const& { return Vendor; }
-  /// The processor name, this includes the vendor specific name
-  [[nodiscard]] virtual auto processorName() const -> std::string const& { return ProcessorName; }
-  /// The model of the processor. With X86 this is the the string of Family, Model and Stepping.
-  [[nodiscard]] virtual auto model() const -> std::string const& = 0;
+
+  /// Get the properties about the hardware threads.
+  [[nodiscard]] auto hardwareThreadsInfo() const -> HardwareThreadsInfo;
 
   /// Getter for the L1i-cache size in bytes
   [[nodiscard]] auto instructionCacheSize() const -> const auto& { return InstructionCacheSize; }
 
   /// Getter for the clockrate in Hz
   [[nodiscard]] virtual auto clockrate() const -> uint64_t { return Clockrate; }
-
-  /// Getter for the list of CPU features
-  [[nodiscard]] virtual auto features() const -> std::list<std::string> const& = 0;
 
   /// Get the current hardware timestamp
   [[nodiscard]] virtual auto timestamp() const -> uint64_t = 0;
@@ -84,6 +77,23 @@ public:
   [[nodiscard]] auto getPkgIdFromPU(unsigned Pu) const -> std::optional<unsigned>;
 
 protected:
+  /// The total number of hardware threads.
+  [[nodiscard]] auto numThreads() const -> unsigned { return NumThreadsPerCore * NumCoresTotal; }
+  /// The total number of cores.
+  [[nodiscard]] auto numCoresTotal() const -> unsigned { return NumCoresTotal; }
+  /// The total number of packages.
+  [[nodiscard]] auto numPackages() const -> unsigned { return NumPackages; }
+  /// The CPU architecture e.g., x86_64
+  [[nodiscard]] auto architecture() const -> std::string const& { return Architecture; }
+  /// The CPU vendor i.e., Intel or AMD.
+  [[nodiscard]] virtual auto vendor() const -> std::string const& { return Vendor; }
+  /// The processor name, this includes the vendor specific name
+  [[nodiscard]] virtual auto processorName() const -> std::string const& { return ProcessorName; }
+  /// The model of the processor. With X86 this is the the string of Family, Model and Stepping.
+  [[nodiscard]] virtual auto model() const -> std::string const& = 0;
+  /// Getter for the list of CPU features
+  [[nodiscard]] virtual auto features() const -> std::list<std::string> const& = 0;
+
   /// Read the scaling_govenor file of cpu0 on linux and return the contents as a string.
   [[nodiscard]] static auto scalingGovernor() -> std::string;
 

--- a/include/firestarter/Environment/CPUTopology.hpp
+++ b/include/firestarter/Environment/CPUTopology.hpp
@@ -37,10 +37,12 @@ namespace firestarter::environment {
 /// This struct describes properties of the threads which are used in the Environment class to assign a specific number
 /// of threads and/or use it for cpu binding.
 struct HardwareThreadsInfo {
+  HardwareThreadsInfo() = default;
+
   /// The number of hardware threads on this system.
-  unsigned MaxNumThreads;
+  unsigned MaxNumThreads = 0;
   /// The highest physical index on a hardware thread in the system.
-  unsigned MaxPhysicalIndex;
+  unsigned MaxPhysicalIndex = 0;
 };
 
 /// This class models the properties of a processor.

--- a/include/firestarter/Environment/X86/X86CPUTopology.hpp
+++ b/include/firestarter/Environment/X86/X86CPUTopology.hpp
@@ -51,7 +51,6 @@ public:
   [[nodiscard]] auto modelId() const -> unsigned { return this->CpuInfo.modelId(); }
   /// The stepping id of the x86 processor
   [[nodiscard]] auto stepping() const -> unsigned { return this->CpuInfo.stepping(); }
-
   /// The CPU vendor i.e., Intel or AMD.
   [[nodiscard]] auto vendor() const -> std::string const& final { return Vendor; }
   /// Get the string containing family, model and stepping ids.

--- a/include/firestarter/Environment/X86/X86CPUTopology.hpp
+++ b/include/firestarter/Environment/X86/X86CPUTopology.hpp
@@ -51,6 +51,7 @@ public:
   [[nodiscard]] auto modelId() const -> unsigned { return this->CpuInfo.modelId(); }
   /// The stepping id of the x86 processor
   [[nodiscard]] auto stepping() const -> unsigned { return this->CpuInfo.stepping(); }
+
   /// The CPU vendor i.e., Intel or AMD.
   [[nodiscard]] auto vendor() const -> std::string const& final { return Vendor; }
   /// Get the string containing family, model and stepping ids.

--- a/src/firestarter/Environment/CPUTopology.cpp
+++ b/src/firestarter/Environment/CPUTopology.cpp
@@ -371,7 +371,9 @@ auto CPUTopology::highestPhysicalIndex() const -> unsigned {
   // Get the number of different kinds of CPUs
   const auto NrCpukinds = hwloc_cpukinds_get_nr(Topology, 0);
 
-  assert(NrCpukinds >= 0 && "flags to hwloc_cpukinds_get_nr is invalid");
+  if (NrCpukinds < 0) {
+    log::fatal() << "flags to hwloc_cpukinds_get_nr is invalid. This is not expected.";
+  }
 
   // No information about the cpukinds found. Go through all PUs and save the biggest os index.
   if (NrCpukinds == 0) {

--- a/src/firestarter/Environment/CPUTopology.cpp
+++ b/src/firestarter/Environment/CPUTopology.cpp
@@ -366,7 +366,7 @@ auto CPUTopology::getPkgIdFromPU(unsigned Pu) const -> std::optional<unsigned> {
 }
 
 auto CPUTopology::hardwareThreadsInfo() const -> HardwareThreadsInfo {
-  HardwareThreadsInfo Infos = {.MaxNumThreads = 0, .MaxPhysicalIndex = 0};
+  HardwareThreadsInfo Infos;
 
   // Get the number of different kinds of CPUs
   const auto NrCpukinds = hwloc_cpukinds_get_nr(Topology, 0);

--- a/src/firestarter/Environment/CPUTopology.cpp
+++ b/src/firestarter/Environment/CPUTopology.cpp
@@ -365,7 +365,7 @@ auto CPUTopology::getPkgIdFromPU(unsigned Pu) const -> std::optional<unsigned> {
   return {};
 }
 
-auto CPUTopology::maxNumThreads() const -> unsigned {
+auto CPUTopology::highestPhysicalIndex() const -> unsigned {
   unsigned Max = 0;
 
   // There might be more then one kind of cores
@@ -398,7 +398,7 @@ auto CPUTopology::maxNumThreads() const -> unsigned {
     if (Result) {
       log::warn() << "Could not get information for CPU kind " << KindIndex;
     }
-    Max += hwloc_bitmap_weight(Bitmap);
+    Max += hwloc_bitmap_last(Bitmap);
   }
 
   hwloc_bitmap_free(Bitmap);

--- a/src/firestarter/Environment/Environment.cpp
+++ b/src/firestarter/Environment/Environment.cpp
@@ -174,7 +174,7 @@ void Environment::evaluateCpuAffinity(unsigned RequestedNumThreads, const std::s
   (void)CpuBind;
 
   if (RequestedNumThreads == 0) {
-    RequestedNumThreads = topology().highestPhysicalIndex() + 1
+    RequestedNumThreads = topology().highestPhysicalIndex() + 1;
   }
 #endif
 

--- a/src/firestarter/Environment/Environment.cpp
+++ b/src/firestarter/Environment/Environment.cpp
@@ -59,7 +59,7 @@ void Environment::addCpuSet(unsigned Cpu, cpu_set_t& Mask) const {
   if (cpuAllowed(Cpu)) {
     CPU_SET(Cpu, &Mask);
   } else {
-    if (Cpu >= topology().hardwareThreadsInfo().MaxPhysicalIndex) {
+    if (Cpu > topology().hardwareThreadsInfo().MaxPhysicalIndex) {
       throw std::invalid_argument("The given bind argument (-b/--bind) includes CPU " + std::to_string(Cpu) +
                                   " that is not available on this system.");
     }

--- a/src/firestarter/Environment/Environment.cpp
+++ b/src/firestarter/Environment/Environment.cpp
@@ -174,7 +174,7 @@ void Environment::evaluateCpuAffinity(unsigned RequestedNumThreads, const std::s
   (void)CpuBind;
 
   if (RequestedNumThreads == 0) {
-    RequestedNumThreads = topology().maxNumThreads();
+    RequestedNumThreads = topology().highestPhysicalIndex() + 1
   }
 #endif
 

--- a/src/firestarter/Environment/Environment.cpp
+++ b/src/firestarter/Environment/Environment.cpp
@@ -87,7 +87,7 @@ void Environment::evaluateCpuAffinity(unsigned RequestedNumThreads, const std::s
 
     // use all CPUs if not defined otherwise
     if (RequestedNumThreads == 0) {
-      for (unsigned I = 0; I < topology().maxNumThreads(); I++) {
+      for (unsigned I = 0; I <= topology().highestPhysicalIndex(); I++) {
         if (cpuAllowed(I)) {
           CPU_SET(I, &Cpuset);
           RequestedNumThreads++;
@@ -96,7 +96,7 @@ void Environment::evaluateCpuAffinity(unsigned RequestedNumThreads, const std::s
     } else {
       // if -n / --threads is set
       unsigned CpuCount = 0;
-      for (unsigned I = 0; I < topology().maxNumThreads(); I++) {
+      for (unsigned I = 0; I <= topology().highestPhysicalIndex(); I++) {
         // skip if cpu is not available
         if (!cpuAllowed(I)) {
           continue;
@@ -165,7 +165,7 @@ void Environment::evaluateCpuAffinity(unsigned RequestedNumThreads, const std::s
   }
 
   // Save the ids of the threads.
-  for (unsigned I = 0; I < topology().maxNumThreads(); I++) {
+  for (unsigned I = 0; I <= topology().highestPhysicalIndex(); I++) {
     if (CPU_ISSET(I, &Cpuset)) {
       this->CpuBind.push_back(I);
     }
@@ -179,7 +179,7 @@ void Environment::evaluateCpuAffinity(unsigned RequestedNumThreads, const std::s
 #endif
 
   // Limit the number of thread to the maximum on the CPU.
-  this->RequestedNumThreads = (std::min)(RequestedNumThreads, topology().maxNumThreads());
+  this->RequestedNumThreads = (std::min)(RequestedNumThreads, topology().highestPhysicalIndex() + 1);
 }
 
 void Environment::printThreadSummary() {


### PR DESCRIPTION
This PR closes #90. We counted the available number of CPUs in the cgroup an then iterated through the physical IDs to find those CPUs. When the physical Id was bigger than the number of available CPUs we could not detect those CPUs.