### PR TITLE
CMake fixes for Roco2

### DIFF
--- a/cmake/BuildOptions.cmake
+++ b/cmake/BuildOptions.cmake
@@ -6,7 +6,7 @@ set_property(CACHE FIRESTARTER_BUILD_TYPE PROPERTY STRINGS FIRESTARTER FIRESTART
 
 # Static linking is not supported with GPU devices or MacOS.
 if(${FIRESTARTER_BUILD_TYPE} STREQUAL "FIRESTARTER" AND NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
-	set(FIRESTARTER_LINK_STATIC "Link FIRESTARTER as a static binary. Note, dlopen is not supported in static binaries. This option is not available on macOS or with CUDA, OneAPI or HIP enabled." ON)
+	option(FIRESTARTER_LINK_STATIC "Link FIRESTARTER as a static binary. Note, dlopen is not supported in static binaries. This option is not available on macOS or with CUDA, OneAPI or HIP enabled." ON)
 endif()
 
 
@@ -22,5 +22,5 @@ option(FIRESTARTER_FETCH_GOOGLETEST "Fetch the Google Test dependency." ON)
 
 # Debug feature are enabled on linux per default.
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-	set(FIRESTARTER_DEBUG_FEATURES "Enable debug features" ON)
+	option(FIRESTARTER_DEBUG_FEATURES "Enable debug features" ON)
 endif()

--- a/cmake/InstallHwloc.cmake
+++ b/cmake/InstallHwloc.cmake
@@ -68,6 +68,6 @@ if (FIRESTARTER_BUILD_HWLOC)
 		endif()
 	endif()
 
-	include_directories(${HWLOC_INCLUDE_DIR}/include)
 	add_dependencies(hwloc HwlocInstall)
+	target_include_directories(hwloc INTERFACE ${HWLOC_INCLUDE_DIR}/include)
 endif()

--- a/cmake/InstallHwloc.cmake
+++ b/cmake/InstallHwloc.cmake
@@ -69,5 +69,9 @@ if (FIRESTARTER_BUILD_HWLOC)
 	endif()
 
 	add_dependencies(hwloc HwlocInstall)
-	target_include_directories(hwloc INTERFACE ${HWLOC_INCLUDE_DIR}/include)
+
+	# Including a non exsistant directory is not allowed. This is the case when configuring and hwloc is not yet installed.
+	# See https://gitlab.kitware.com/cmake/cmake/-/issues/15052
+	file(MAKE_DIRECTORY "${HWLOC_INCLUDE_DIR}/include")
+	target_include_directories(hwloc INTERFACE "${HWLOC_INCLUDE_DIR}/include")
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -64,13 +64,25 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 		)
 endif()
 
-
-SET(FIRESTARTER_FILES
-	firestarter/Main.cpp
-
+add_library(firestartercombined STATIC
 	# IpcEstimateMetricData::insertValue is accesses which is part of the firestarterlinux library.
 	# This reference should be removed there and the file moved back to the firestartercore library.
 	firestarter/LoadWorker.cpp
+)
+
+target_link_libraries(firestartercombined
+	firestartercore
+	)
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+	target_link_libraries(firestartercombined
+		firestarterlinux
+		)
+endif()
+
+
+SET(FIRESTARTER_FILES
+	firestarter/Main.cpp
 	)
 
 if ("${FIRESTARTER_BUILD_TYPE}" STREQUAL "FIRESTARTER_CUDA")
@@ -80,14 +92,8 @@ if ("${FIRESTARTER_BUILD_TYPE}" STREQUAL "FIRESTARTER_CUDA")
 		)
 
 	target_link_libraries(FIRESTARTER_CUDA
-		firestartercore
+		firestartercombined
 	)
-
-	if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-		target_link_libraries(FIRESTARTER_CUDA
-			firestarterlinux
-		)
-	endif()
 
 	target_link_libraries(FIRESTARTER_CUDA
 		CUDA::cuda_driver
@@ -114,14 +120,8 @@ elseif ("${FIRESTARTER_BUILD_TYPE}" STREQUAL "FIRESTARTER_ONEAPI")
 		)
 
 	target_link_libraries(FIRESTARTER_ONEAPI
-		firestartercore
+		firestartercombined
 	)
-
-	if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-		target_link_libraries(FIRESTARTER_ONEAPI
-			firestarterlinux
-		)
-	endif()
 
 	target_link_libraries(FIRESTARTER_ONEAPI
 		mkl_sycl
@@ -140,14 +140,8 @@ elseif("${FIRESTARTER_BUILD_TYPE}" STREQUAL "FIRESTARTER_HIP")
 		)
 
 	target_link_libraries(FIRESTARTER_HIP
-		firestartercore
+		firestartercombined
 	)
-
-	if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-		target_link_libraries(FIRESTARTER_HIP
-			firestarterlinux
-		)
-	endif()
 
 	target_link_libraries(FIRESTARTER_HIP
 		hip::host
@@ -168,14 +162,8 @@ elseif(${FIRESTARTER_BUILD_TYPE} STREQUAL "FIRESTARTER")
 		)
 
 	target_link_libraries(FIRESTARTER
-		firestartercore
+		firestartercombined
 	)
-
-	if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-		target_link_libraries(FIRESTARTER
-			firestarterlinux
-		)
-	endif()
 
 	target_link_libraries_darwin(NAME FIRESTARTER)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,6 +30,8 @@ add_library(firestartercore STATIC
 	firestarter/X86/Payload/SSE2Payload.cpp
 	)
 
+target_include_directories(firestartercore PUBLIC ${PROJECT_SOURCE_DIR}/include)
+
 target_link_libraries(firestartercore
 	hwloc
 	AsmJit::AsmJit
@@ -53,6 +55,8 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 		firestarter/Optimizer/Util/MultiObjective.cpp
 		firestarter/Optimizer/Algorithm/NSGA2.cpp
 		)
+	
+	target_include_directories(firestarterlinux PUBLIC ${PROJECT_SOURCE_DIR}/include)
 
 	target_link_libraries(firestarterlinux
 		Nitro::log

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -80,10 +80,21 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 		)
 endif()
 
-
 SET(FIRESTARTER_FILES
 	firestarter/Main.cpp
 	)
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+	SET(FIRESTARTER_LIBRARIES
+		firestartercombined
+	)
+else()
+	SET(FIRESTARTER_LIBRARIES
+		"-Wl,--whole-archive"
+		firestartercombined
+		"-Wl,--no-whole-archive"
+	)
+endif()
 
 if ("${FIRESTARTER_BUILD_TYPE}" STREQUAL "FIRESTARTER_CUDA")
 	add_executable(FIRESTARTER_CUDA
@@ -92,9 +103,7 @@ if ("${FIRESTARTER_BUILD_TYPE}" STREQUAL "FIRESTARTER_CUDA")
 		)
 
 	target_link_libraries(FIRESTARTER_CUDA
-		"-Wl,--whole-archive"
-		firestartercombined
-		"-Wl,--no-whole-archive"
+		${FIRESTARTER_LIBRARIES}
 	)
 
 	target_link_libraries(FIRESTARTER_CUDA
@@ -122,9 +131,7 @@ elseif ("${FIRESTARTER_BUILD_TYPE}" STREQUAL "FIRESTARTER_ONEAPI")
 		)
 
 	target_link_libraries(FIRESTARTER_ONEAPI
-		"-Wl,--whole-archive"
-		firestartercombined
-		"-Wl,--no-whole-archive"
+		${FIRESTARTER_LIBRARIES}
 	)
 
 	target_link_libraries(FIRESTARTER_ONEAPI
@@ -144,9 +151,7 @@ elseif("${FIRESTARTER_BUILD_TYPE}" STREQUAL "FIRESTARTER_HIP")
 		)
 
 	target_link_libraries(FIRESTARTER_HIP
-		"-Wl,--whole-archive"
-		firestartercombined
-		"-Wl,--no-whole-archive"
+		${FIRESTARTER_LIBRARIES}
 	)
 
 	target_link_libraries(FIRESTARTER_HIP
@@ -168,9 +173,7 @@ elseif(${FIRESTARTER_BUILD_TYPE} STREQUAL "FIRESTARTER")
 		)
 
 	target_link_libraries(FIRESTARTER
-		"-Wl,--whole-archive"
-		firestartercombined
-		"-Wl,--no-whole-archive"
+		${FIRESTARTER_LIBRARIES}
 	)
 
 	target_link_libraries_darwin(NAME FIRESTARTER)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -92,7 +92,9 @@ if ("${FIRESTARTER_BUILD_TYPE}" STREQUAL "FIRESTARTER_CUDA")
 		)
 
 	target_link_libraries(FIRESTARTER_CUDA
+		"-Wl,--whole-archive"
 		firestartercombined
+		"-Wl,--no-whole-archive"
 	)
 
 	target_link_libraries(FIRESTARTER_CUDA
@@ -120,7 +122,9 @@ elseif ("${FIRESTARTER_BUILD_TYPE}" STREQUAL "FIRESTARTER_ONEAPI")
 		)
 
 	target_link_libraries(FIRESTARTER_ONEAPI
+		"-Wl,--whole-archive"
 		firestartercombined
+		"-Wl,--no-whole-archive"
 	)
 
 	target_link_libraries(FIRESTARTER_ONEAPI
@@ -140,7 +144,9 @@ elseif("${FIRESTARTER_BUILD_TYPE}" STREQUAL "FIRESTARTER_HIP")
 		)
 
 	target_link_libraries(FIRESTARTER_HIP
+		"-Wl,--whole-archive"
 		firestartercombined
+		"-Wl,--no-whole-archive"
 	)
 
 	target_link_libraries(FIRESTARTER_HIP
@@ -162,7 +168,9 @@ elseif(${FIRESTARTER_BUILD_TYPE} STREQUAL "FIRESTARTER")
 		)
 
 	target_link_libraries(FIRESTARTER
+		"-Wl,--whole-archive"
 		firestartercombined
+		"-Wl,--no-whole-archive"
 	)
 
 	target_link_libraries_darwin(NAME FIRESTARTER)


### PR DESCRIPTION
This PR includes fixes in the CMake that allows firestarter to be used as an external library. This PR closes #104. It is the requirement for https://github.com/tud-zih-energy/roco2/pull/11.