### PR TITLE
RAPL Submetrics

### DIFF
--- a/cmake/InstallGoogleTest.cmake
+++ b/cmake/InstallGoogleTest.cmake
@@ -2,7 +2,7 @@
 
 # configure build of googletest
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-set(BUILD_GMOCK OFF CACHE BOOL "" FORCE)
+set(BUILD_GMOCK ON CACHE BOOL "" FORCE)
 
 # Do not execute the google test executable during build.
 set(CMAKE_GTEST_DISCOVER_TESTS_DISCOVERY_MODE PRE_TEST)

--- a/include/firestarter/Config/Config.hpp
+++ b/include/firestarter/Config/Config.hpp
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "firestarter/Config/InstructionGroups.hpp"
+#include "firestarter/Config/MetricName.hpp"
 
 #include <chrono>
 #include <cstdint>
@@ -67,7 +68,7 @@ struct Config {
   /// The paths to the metrics that are loaded using shared libraries.
   std::vector<std::string> MetricPaths;
   /// The list of metrics that are used for maximization. If a metric is prefixed with '-' it will be minimized.
-  std::vector<std::string> OptimizationMetrics;
+  std::vector<MetricName> OptimizationMetrics;
 
   /// The optional cpu bind that allow pinning to specific cpus.
   std::optional<std::set<uint64_t>> CpuBinding;

--- a/include/firestarter/Config/Config.hpp
+++ b/include/firestarter/Config/Config.hpp
@@ -67,7 +67,7 @@ struct Config {
   std::set<std::string> StdinMetrics;
   /// The paths to the metrics that are loaded using shared libraries.
   std::set<std::string> MetricPaths;
-  /// The list of metrics that are used for maximization. If a metric is prefixed with '-' it will be minimized.
+  /// The set of metrics that are used for maximization. If a metric is prefixed with '-' it will be minimized.
   std::set<MetricName> OptimizationMetrics;
 
   /// The optional cpu bind that allow pinning to specific cpus.

--- a/include/firestarter/Config/Config.hpp
+++ b/include/firestarter/Config/Config.hpp
@@ -64,11 +64,11 @@ struct Config {
   double Nsga2M;
 
   /// The name of the metrics that are read from stdin.
-  std::vector<std::string> StdinMetrics;
+  std::set<std::string> StdinMetrics;
   /// The paths to the metrics that are loaded using shared libraries.
-  std::vector<std::string> MetricPaths;
+  std::set<std::string> MetricPaths;
   /// The list of metrics that are used for maximization. If a metric is prefixed with '-' it will be minimized.
-  std::vector<MetricName> OptimizationMetrics;
+  std::set<MetricName> OptimizationMetrics;
 
   /// The optional cpu bind that allow pinning to specific cpus.
   std::optional<std::set<uint64_t>> CpuBinding;

--- a/include/firestarter/Config/MetricName.hpp
+++ b/include/firestarter/Config/MetricName.hpp
@@ -30,7 +30,7 @@ namespace firestarter {
 struct MetricName {
   MetricName() = delete;
 
-  MetricName(bool Inverted, std::string RootMetricName, std::optional<std::string> SubmetricName)
+  MetricName(bool Inverted, std::string RootMetricName, std::optional<std::string> SubmetricName = {})
       : Inverted(Inverted)
       , RootMetricName(std::move(RootMetricName))
       , SubmetricName(std::move(SubmetricName)) {}
@@ -56,7 +56,7 @@ struct MetricName {
   /// Do two MetricName share the same metrics?
   /// \arg Other The MetricName that is compared against.
   /// \returns true if the two names share the same metric
-  [[nodiscard]] auto isSameMetric(const MetricName& Other) -> bool {
+  [[nodiscard]] auto isSameMetric(const MetricName& Other) const -> bool {
     return std::tie(RootMetricName, SubmetricName) == std::tie(Other.rootMetricName(), Other.submetricName());
   }
 
@@ -70,3 +70,15 @@ private:
 };
 
 } // namespace firestarter
+
+template <> struct std::hash<firestarter::MetricName> {
+  auto operator()(firestarter::MetricName const& Name) const noexcept -> std::size_t {
+    return std::hash<std::string>{}(Name.toString());
+  }
+};
+
+template <> struct std::less<firestarter::MetricName> {
+  auto operator()(firestarter::MetricName const& Lhs, firestarter::MetricName const& Rhs) const noexcept -> bool {
+    return std::less<std::string>{}(Lhs.toString(), Rhs.toString());
+  }
+};

--- a/include/firestarter/Config/MetricName.hpp
+++ b/include/firestarter/Config/MetricName.hpp
@@ -48,7 +48,7 @@ struct MetricName {
   }
 
   /// Is the metric inverted
-  [[nodiscard]] auto inverted() const -> auto { return Inverted; }
+  [[nodiscard]] auto inverted() const -> const auto& { return Inverted; }
   /// The name of the root metric
   [[nodiscard]] auto rootMetricName() const -> const auto& { return RootMetricName; }
   /// The optional name of the submetric
@@ -59,6 +59,11 @@ struct MetricName {
   /// \returns true if the two names share the same metric
   [[nodiscard]] auto isSameMetric(const MetricName& Other) const -> bool {
     return std::tie(RootMetricName, SubmetricName) == std::tie(Other.rootMetricName(), Other.submetricName());
+  }
+
+  auto operator==(const MetricName& Other) const -> bool {
+    return std::tie(Inverted, RootMetricName, SubmetricName) ==
+           std::tie(Other.inverted(), Other.rootMetricName(), Other.submetricName());
   }
 
 private:

--- a/include/firestarter/Config/MetricName.hpp
+++ b/include/firestarter/Config/MetricName.hpp
@@ -30,8 +30,8 @@ namespace firestarter {
 
 /// This struct handels the name of a metric. It can be created from a string and converted back into a string.
 /// The metric name constains the name of the root metric and optionally the name of a submetric. These values are used
-/// to check if two metric names are the same. In addition to that the name can contain additional attribute. Currently
-/// this is only the flag to invert the metric value for the optimization.
+/// to check if two metric names are the same. It can also contain additional attributes. Currently this is only the
+/// flag to invert the metric value for the optimization.
 struct MetricName {
   MetricName() = delete;
 

--- a/include/firestarter/Config/MetricName.hpp
+++ b/include/firestarter/Config/MetricName.hpp
@@ -1,0 +1,65 @@
+/******************************************************************************
+ * FIRESTARTER - A Processor Stress Test Utility
+ * Copyright (C) 2025 TU Dresden, Center for Information Services and High
+ * Performance Computing
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/\>.
+ *
+ * Contact: daniel.hackenberg@tu-dresden.de
+ *****************************************************************************/
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <utility>
+
+namespace firestarter {
+
+struct MetricName {
+  MetricName() = delete;
+
+  MetricName(bool Inverted, std::string RootMetricName, std::optional<std::string> SubmetricName)
+      : Inverted(Inverted)
+      , RootMetricName(std::move(RootMetricName))
+      , SubmetricName(std::move(SubmetricName)) {}
+
+  /// Parse the metric name. It consists of an optional minus ('-') the root metric name, and an optional slash ('/')
+  /// followed by the submetric name.
+  /// \arg MetricName The name of the metric
+  [[nodiscard]] static auto fromString(const std::string& Metric) -> MetricName;
+
+  /// Convert the internal metric name to a string following the format: optional minus ('-') for an inverted metric,
+  /// the root metric name, and an optional slash ('/') followed by the submetric name.
+  [[nodiscard]] auto toString() const -> std::string {
+    return (Inverted ? "-" : "") + RootMetricName + (SubmetricName ? ("/" + *SubmetricName) : "");
+  }
+
+  /// Is the metric inverted
+  [[nodiscard]] auto inverted() const -> auto { return Inverted; }
+  /// The name of the root metric
+  [[nodiscard]] auto rootMetricName() const -> const auto& { return RootMetricName; }
+  /// The optional name of the submetric
+  [[nodiscard]] auto submetricName() const -> const auto& { return SubmetricName; }
+
+private:
+  /// True if the metric is inverted
+  bool Inverted;
+  /// The name of the root metric
+  std::string RootMetricName;
+  /// The optional name of the submetric
+  std::optional<std::string> SubmetricName;
+};
+
+} // namespace firestarter

--- a/include/firestarter/Config/MetricName.hpp
+++ b/include/firestarter/Config/MetricName.hpp
@@ -53,6 +53,13 @@ struct MetricName {
   /// The optional name of the submetric
   [[nodiscard]] auto submetricName() const -> const auto& { return SubmetricName; }
 
+  /// Do two MetricName share the same metrics?
+  /// \arg Other The MetricName that is compared against.
+  /// \returns true if the two names share the same metric
+  [[nodiscard]] auto isSameMetric(const MetricName& Other) -> bool {
+    return std::tie(RootMetricName, SubmetricName) == std::tie(Other.rootMetricName(), Other.submetricName());
+  }
+
 private:
   /// True if the metric is inverted
   bool Inverted;

--- a/include/firestarter/Config/MetricName.hpp
+++ b/include/firestarter/Config/MetricName.hpp
@@ -23,6 +23,7 @@
 
 #include <optional>
 #include <string>
+#include <tuple>
 #include <utility>
 
 namespace firestarter {

--- a/include/firestarter/Json/MetricName.hpp
+++ b/include/firestarter/Json/MetricName.hpp
@@ -21,29 +21,20 @@
 
 #pragma once
 
-#include "firestarter/Measurement/Summary.hpp"
+#include "firestarter/Config/MetricName.hpp"
 
 #include <nlohmann/json.hpp>
 
-/// Json serializer and deserializer for the firestarter::measurement::Summary struct
+/// Json serializer and deserializer for the firestarter::MetricName struct
 namespace nlohmann {
-template <> struct adl_serializer<firestarter::measurement::Summary> {
+template <> struct adl_serializer<firestarter::MetricName> {
   // functions for nlohmann json do not follow LLVM code style
   // NOLINTBEGIN(readability-identifier-naming)
-  static auto from_json(const json& J) -> firestarter::measurement::Summary {
-    return {J["num_timepoints"].get<size_t>(),
-            std::chrono::milliseconds(J["duration"].get<std::chrono::milliseconds::rep>()), J["average"].get<double>(),
-            J["stddev"].get<double>()};
+  static auto from_json(const json& J) -> firestarter::MetricName {
+    return firestarter::MetricName::fromString(J.get<std::string>());
   }
 
-  static void to_json(json& J, firestarter::measurement::Summary S) {
-    J = json::object();
-
-    J["num_timepoints"] = S.NumTimepoints;
-    J["duration"] = S.Duration.count();
-    J["average"] = S.Average;
-    J["stddev"] = S.Stddev;
-  }
+  static void to_json(json& J, const firestarter::MetricName& Name) { J = Name.toString(); }
   // NOLINTEND(readability-identifier-naming)
 };
 } // namespace nlohmann

--- a/include/firestarter/Measurement/MeasurementWorker.hpp
+++ b/include/firestarter/Measurement/MeasurementWorker.hpp
@@ -31,6 +31,7 @@
 #include <functional>
 #include <memory>
 #include <sstream>
+#include <thread>
 
 namespace firestarter::measurement {
 

--- a/include/firestarter/Measurement/MeasurementWorker.hpp
+++ b/include/firestarter/Measurement/MeasurementWorker.hpp
@@ -63,11 +63,11 @@ private:
   const uint64_t NumThreads;
 
   /// The thread function handles the timed polling of the metric values and saves them to the Value datastructure.
-  static void dataAcquisitionWorker(void* MeasurementWorker);
+  static void dataAcquisitionWorker(MeasurementWorker& This);
 
   /// The thread function that handles the acquisition of the metric values from stdin and saves them to the Value
   /// datastructure.
-  static void stdinDataAcquisitionWorker(void* MeasurementWorker);
+  static void stdinDataAcquisitionWorker(MeasurementWorker& This);
 
   /// Return the pointer to a metric from the Metrics vector that matches the supplied name.
   /// \arg MetricName The name of the metric

--- a/include/firestarter/Measurement/MeasurementWorker.hpp
+++ b/include/firestarter/Measurement/MeasurementWorker.hpp
@@ -26,6 +26,7 @@
 #include "firestarter/Measurement/Metric/Perf.hpp"
 #include "firestarter/Measurement/Metric/RAPL.hpp"
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <functional>

--- a/include/firestarter/Measurement/MeasurementWorker.hpp
+++ b/include/firestarter/Measurement/MeasurementWorker.hpp
@@ -51,8 +51,8 @@ private:
   /// The vector of metrics that are available. Currently the following metrics are builtin: sysfs-powercap-rapl,
   /// perf-ipc, perf-freq and ipc-estimate. Metric provided through shared libraries are added to this list.
   std::vector<std::shared_ptr<RootMetric>> Metrics = {
-      RootMetric::fromCInterface(RaplMetric), RootMetric::fromCInterface(PerfIpcMetric),
-      RootMetric::fromCInterface(PerfFreqMetric), RootMetric::fromCInterface(IpcEstimateMetric)};
+      RootMetric::fromCInterface(RaplMetric::Metric), RootMetric::fromCInterface(PerfMetric::PerfIpcMetric),
+      RootMetric::fromCInterface(PerfMetric::PerfFreqMetric), RootMetric::fromCInterface(IpcEstimateMetric::Metric)};
 
   /// We poll the values of all the metrics after this number of milliseconds.
   std::chrono::milliseconds UpdateInterval;

--- a/include/firestarter/Measurement/MeasurementWorker.hpp
+++ b/include/firestarter/Measurement/MeasurementWorker.hpp
@@ -109,9 +109,9 @@ public:
   /// Initilize the measurement worker. It will spawn the threads for the polling of metic values.
   /// \arg UpdateInterval The polling time for metric updates.
   /// \arg NumThreads The number of thread FIRESTARTER is running with.
-  /// \arg MetricDylibsNames The vector of files to which are passed to dlopen for using additional metrics from shared
+  /// \arg MetricDylibsNames The set of files to which are passed to dlopen for using additional metrics from shared
   /// libraries.
-  /// \arg StdinMetricsNames The vector of metric names that should be read in from stdin
+  /// \arg StdinMetricsNames The set of metric names that should be read in from stdin
   MeasurementWorker(std::chrono::milliseconds UpdateInterval, uint64_t NumThreads,
                     std::set<std::string> const& MetricDylibsNames, std::set<std::string> const& StdinMetricsNames);
 

--- a/include/firestarter/Measurement/MeasurementWorker.hpp
+++ b/include/firestarter/Measurement/MeasurementWorker.hpp
@@ -84,10 +84,11 @@ private:
     return *MetricReference;
   }
 
-  /// Get all metrics matching a filter function defined on the std::shared_ptr<RootMetric>
+  /// Get all metrics matching a filter function that takes the Root metric as a std::shared_ptr<RootMetric> and return
+  /// true if the metric should be kept in the output set.
   /// \arg FilterFunction The function that take a shared_ptr to the RootMetric and returns
   /// true if the metric names of this metric should be saved.
-  /// \return The vector of filtered metric names.
+  /// \return The set of filtered metric names.
   auto metrics(const std::function<bool(const std::shared_ptr<RootMetric>&)>& FilterFunction) -> std::set<MetricName> {
     std::set<MetricName> MetricNames;
     for (const auto& Metric : Metrics) {
@@ -97,7 +98,7 @@ private:
           const auto [Iterator, Inserted] = MetricNames.emplace(Name);
           if (!Inserted) {
             throw std::runtime_error("Failed to insert MetricName: " + Name.toString() + " from RootMetric: " +
-                                     Metric->metricName().toString() + ". Another another entry exsists.");
+                                     Metric->metricName().toString() + ". Another another entry exists.");
           }
         }
       }
@@ -165,7 +166,6 @@ public:
 
   /// Initialize the metrics with the provided names.
   /// \arg MetricNames The metrics to initialize
-  /// \returns The vector of metrics that were successfully initialized.
   void initMetrics(std::set<MetricName> const& MetricNames);
 
   /// Set the StartTime to the current timestep

--- a/include/firestarter/Measurement/Metric.hpp
+++ b/include/firestarter/Measurement/Metric.hpp
@@ -36,7 +36,7 @@
 #include <utility>
 #include <vector>
 
-#ifndef FIRESTARTER_LINK_STATIC
+#if not(defined(FIRESTARTER_LINK_STATIC)) && defined(linux)
 extern "C" {
 #include <dlfcn.h>
 }
@@ -97,7 +97,7 @@ struct RootMetric : public Metric {
       MetricPtr->Fini();
     }
 
-#ifndef FIRESTARTER_LINK_STATIC
+#if not(defined(FIRESTARTER_LINK_STATIC)) && defined(linux)
     if (Dylib) {
       dlclose(MetricPtr);
     }
@@ -117,7 +117,7 @@ struct RootMetric : public Metric {
     return Root;
   }
 
-#ifndef FIRESTARTER_LINK_STATIC
+#if not(defined(FIRESTARTER_LINK_STATIC)) && defined(linux)
   /// Popuplate the RootMetric object from the C-style MetricInterface provided via a dynamic library.
   /// \arg DylibPath The dynamic library name
   static auto fromDylib(const std::string& DylibPath) -> std::shared_ptr<RootMetric> {

--- a/include/firestarter/Measurement/Metric.hpp
+++ b/include/firestarter/Measurement/Metric.hpp
@@ -1,0 +1,309 @@
+/******************************************************************************
+ * FIRESTARTER - A Processor Stress Test Utility
+ * Copyright (C) 2024 TU Dresden, Center for Information Services and High
+ * Performance Computing
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/\>.
+ *
+ * Contact: daniel.hackenberg@tu-dresden.de
+ *****************************************************************************/
+
+#pragma once
+
+#include "firestarter/Logging/Log.hpp"
+#include "firestarter/Measurement/MetricInterface.h"
+#include "firestarter/Measurement/Summary.hpp"
+#include "firestarter/Measurement/TimeValue.hpp"
+
+#include <cassert>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#ifndef FIRESTARTER_LINK_STATIC
+extern "C" {
+#include <dlfcn.h>
+}
+#endif
+
+namespace firestarter::measurement {
+
+/// This class handels the state around a metric. Its name and if it is initialized or available.
+struct Metric {
+
+  Metric() = delete;
+
+  explicit Metric(std::string Name)
+      : Name(std::move(Name)) {}
+
+  /// The name of the metric
+  std::string Name;
+  /// Is the metric available
+  bool Available = false;
+  /// The data collected from the metrics.
+  std::vector<TimeValue> Values;
+  /// Mutex to access the Values
+  std::mutex ValuesMutex;
+};
+
+/// This class handels the state around a leaf metric. Its name and if it is initialized or available.
+struct LeafMetric : public Metric {};
+
+/// This class handels the state around a root metric. Its name, if it is initialized and available and the pointer to
+/// the interface to interact with it.
+/// Root metrics include addition leaf-/sub- metrics.
+struct RootMetric : public Metric {
+  /// The pointer to the metric
+  MetricInterface* MetricPtr = nullptr;
+  /// The names of the submetrics.
+  std::vector<LeafMetric> Submetrics;
+  /// Is the metric from a dynamic library
+  bool Dylib;
+  /// Is the metric from stdin input?
+  bool Stdin;
+  /// Is the metric initialized
+  bool Initialized = false;
+
+  RootMetric() = delete;
+
+  /// \arg Name The name of the metric
+  /// \arg Available Is the metric available
+  RootMetric(std::string Name, bool Dylib, bool Stdin, bool Initialized)
+      : Metric(std::move(Name))
+      , Dylib(Dylib)
+      , Stdin(Stdin)
+      , Initialized(Initialized) {}
+
+  ~RootMetric() {
+    if (Initialized && MetricPtr) {
+      MetricPtr->Fini();
+    }
+
+#ifndef FIRESTARTER_LINK_STATIC
+    if (Dylib) {
+      dlclose(MetricPtr);
+    }
+#endif
+    Initialized = false;
+  }
+
+  /// Popuplate the RootMetric object from the C-style MetricInterface.
+  /// \arg Metric the refernce to the C-style MetricInterface
+  static auto fromCInterface(MetricInterface& Metric) -> std::shared_ptr<RootMetric> {
+    auto Root = std::make_shared<RootMetric>(/*Name=*/Metric.Name,
+                                             /*Dylib=*/false,
+                                             /*Stdin=*/false,
+                                             /*Initialized=*/false);
+    Root->MetricPtr = &Metric;
+    Root->checkAvailability();
+    return Root;
+  }
+
+#ifndef FIRESTARTER_LINK_STATIC
+  /// Popuplate the RootMetric object from the C-style MetricInterface provided via a dynamic library.
+  /// \arg DylibPath The dynamic library name
+  static auto fromDylib(const std::string& DylibPath) -> std::shared_ptr<RootMetric> {
+    void* Handle = nullptr;
+    const char* Filename = DylibPath.c_str();
+
+    Handle = dlopen(Filename, RTLD_NOW | RTLD_LOCAL);
+
+    if (!Handle) {
+      firestarter::log::error() << Filename << ": " << dlerror();
+      return nullptr;
+    }
+
+    // clear existing error
+    dlerror();
+
+    MetricInterface* Metric = nullptr;
+
+    Metric = static_cast<MetricInterface*>(dlsym(Handle, "metric"));
+
+    char* Error = nullptr;
+    if ((Error = dlerror()) != nullptr) {
+      firestarter::log::error() << Filename << ": " << Error;
+      dlclose(Handle);
+      return nullptr;
+    }
+
+    auto Root = std::make_shared<RootMetric>(/*Name=*/Metric->Name,
+                                             /*Dylib=*/true,
+                                             /*Stdin=*/false,
+                                             /*Initialized=*/false);
+    Root->checkAvailability();
+    return Root;
+  }
+#endif
+
+  /// Popuplate the RootMetric object from the C-style MetricInterface.
+  /// \arg Metric the refernce to the C-style MetricInterface
+  static auto fromStdin(const std::string& MetricName) -> std::shared_ptr<RootMetric> {
+    auto Root = std::make_shared<RootMetric>(/*Name=*/MetricName,
+                                             /*Dylib=*/false,
+                                             /*Stdin=*/true,
+                                             /*Initialized=*/true);
+
+    Root->checkAvailability();
+    return Root;
+  }
+
+  auto initialize() -> bool {
+    log::debug() << "Initializing metric " << Name;
+
+    // Clear the contained data
+    {
+      std::lock_guard<std::mutex> Lock(ValuesMutex);
+      Values.clear();
+    }
+    // Init the associated metric interface object
+    if (MetricPtr) {
+      const auto ReturnValue = MetricPtr->Init();
+
+      Initialized = ReturnValue == EXIT_SUCCESS;
+      if (!Initialized) {
+        log::warn() << "Metric " << Name << ": " << MetricPtr->GetError();
+        return false;
+      }
+
+      // Register the callback to insert data
+      if (MetricPtr->Type.InsertCallback) {
+        MetricPtr->RegisterInsertCallback(insertCallback, this);
+      }
+    }
+
+    return true;
+  }
+
+  /// Get the callback function and callback interval that has to be executed in a timed fashion for the metric.
+  /// \returns an empty optional if the metric does not required timed callbacks. otherwise it returns a tuple of the
+  /// callback function and callback interval. The callback function should be called after the callback interval has
+  /// expired.
+  auto getTimedCallback() -> std::optional<std::tuple<std::function<void()>, std::chrono::microseconds>> {
+    if (!MetricPtr) {
+      return {};
+    }
+
+    auto CallbackTime = std::chrono::microseconds(MetricPtr->CallbackTime);
+    if (CallbackTime.count() == 0) {
+      return {};
+    }
+
+    auto Callback = [this]() {
+      if (Initialized) {
+        MetricPtr->Callback();
+      }
+    };
+
+    return std::tuple<std::function<void()>, std::chrono::microseconds>{Callback, CallbackTime};
+  }
+
+  /// Get the optional callback that has to be executed to insert values into the metric storage.
+  /// \return optionally returns the function that has to be executed to save the current metric value into the
+  /// stoarage.
+  auto getInsertCallback() -> std::optional<std::function<void()>> {
+    if (!MetricPtr) {
+      return {};
+    }
+
+    auto Callback = [this]() {
+      double Value = NAN;
+
+      if (Initialized && EXIT_SUCCESS == MetricPtr->GetReading(&Value)) {
+        insert(std::chrono::high_resolution_clock::now(), Value);
+      }
+    };
+
+    if (!MetricPtr->Type.InsertCallback && MetricPtr->GetReading != nullptr) {
+      return Callback;
+    }
+
+    return {};
+  }
+
+  void insert(std::chrono::high_resolution_clock::time_point Time, double Value) {
+    const std::lock_guard<std::mutex> Lock(ValuesMutex);
+    Values.emplace_back(Time, Value);
+  }
+
+  void insert(int64_t TimeSinceEpoch, double Value) {
+    // TODO: allow inserting the sub metric
+    using Duration = std::chrono::duration<int64_t, std::nano>;
+    auto Time = std::chrono::time_point<std::chrono::high_resolution_clock, Duration>(Duration(TimeSinceEpoch));
+
+    insert(Time, Value);
+  }
+
+  [[nodiscard]] auto getSummary(std::chrono::high_resolution_clock::time_point StartTime,
+                                std::chrono::high_resolution_clock::time_point StopTime,
+                                std::chrono::milliseconds StartDelta, std::chrono::milliseconds StopDelta,
+                                const uint64_t NumThreads) -> Summary {
+    MetricType Type{};
+
+    if (MetricPtr == nullptr) {
+      Type.Absolute = 1;
+
+      StartTime += StartDelta;
+      StopTime -= StopDelta;
+    } else {
+      Type = MetricPtr->Type;
+
+      if (!Type.IgnoreStartStopDelta) {
+        StartTime += StartDelta;
+        StopTime -= StopDelta;
+      }
+    }
+
+    decltype(Values) CroppedValues;
+
+    {
+      std::lock_guard<std::mutex> Lock(ValuesMutex);
+
+      auto FindAll = [&StartTime, &StopTime](auto const& Tv) { return StartTime <= Tv.Time && Tv.Time <= StopTime; };
+      std::copy_if(Values.begin(), Values.end(), std::back_inserter(CroppedValues), FindAll);
+    }
+
+    return Summary::calculate(CroppedValues.begin(), CroppedValues.end(), Type, NumThreads);
+  }
+
+private:
+  void checkAvailability() {
+    if (MetricPtr) {
+      auto ReturnCode = MetricPtr->Init();
+      MetricPtr->Fini();
+      Available = ReturnCode == EXIT_SUCCESS;
+    } else {
+      Available = true;
+    }
+  }
+
+  /// This function insert a time value pair for a specific metric. This function will be provided to metrics to
+  /// allow them to push time value pairs.
+  /// \arg MetricName The name of the metric for which values are inserted
+  /// \arg TimeSinceEpoch The time since epoch of the time value pair
+  /// \arg Value The value of the time value pair
+  static void insertCallback(void* Cls, const char* /*MetricName*/, int64_t TimeSinceEpoch, double Value) {
+    assert(Cls && "External metric does not provide Cls argument");
+    auto& This = *static_cast<RootMetric*>(Cls);
+    // TODO: allow inserting into the sub metrics
+    This.insert(TimeSinceEpoch, Value);
+  }
+};
+
+} // namespace firestarter::measurement

--- a/include/firestarter/Measurement/Metric.hpp
+++ b/include/firestarter/Measurement/Metric.hpp
@@ -193,7 +193,7 @@ struct RootMetric : public Metric {
       // Get the submetrics
       if (MetricPtr->GetSubmetricNames) {
         // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-        for (auto** Names = MetricPtr->GetSubmetricNames(); Names; Names++) {
+        for (auto** Names = MetricPtr->GetSubmetricNames(); *Names; Names++) {
           // Create a new submetric entry for each name
           Submetrics.emplace_back(std::make_unique<LeafMetric>(std::string(*Names)));
         }

--- a/include/firestarter/Measurement/Metric.hpp
+++ b/include/firestarter/Measurement/Metric.hpp
@@ -240,10 +240,12 @@ struct RootMetric : public Metric {
     }
 
     auto Callback = [this]() {
-      double Value = NAN;
+      std::vector<double> Values(1 + Submetrics.size(), NAN);
 
-      if (Initialized && EXIT_SUCCESS == MetricPtr->GetReading(&Value)) {
-        insert(/*MetricIndex=*/ROOT_METRIC_INDEX, std::chrono::high_resolution_clock::now(), Value);
+      if (Initialized && EXIT_SUCCESS == MetricPtr->GetReading(Values.data(), Values.size())) {
+        for (auto I = 0U; I < Values.size(); I++) {
+          insert(/*MetricIndex=*/I, std::chrono::high_resolution_clock::now(), Values[I]);
+        }
       }
     };
 

--- a/include/firestarter/Measurement/Metric.hpp
+++ b/include/firestarter/Measurement/Metric.hpp
@@ -1,6 +1,6 @@
 /******************************************************************************
  * FIRESTARTER - A Processor Stress Test Utility
- * Copyright (C) 2024 TU Dresden, Center for Information Services and High
+ * Copyright (C) 2025 TU Dresden, Center for Information Services and High
  * Performance Computing
  *
  * This program is free software: you can redistribute it and/or modify
@@ -43,6 +43,8 @@ extern "C" {
 #endif
 
 namespace firestarter::measurement {
+
+static void insertCallback(void* Cls, const char* /*MetricName*/, int64_t TimeSinceEpoch, double Value);
 
 /// This class handels the state around a metric. Its name and if it is initialized or available.
 struct Metric {
@@ -292,18 +294,18 @@ private:
       Available = true;
     }
   }
-
-  /// This function insert a time value pair for a specific metric. This function will be provided to metrics to
-  /// allow them to push time value pairs.
-  /// \arg MetricName The name of the metric for which values are inserted
-  /// \arg TimeSinceEpoch The time since epoch of the time value pair
-  /// \arg Value The value of the time value pair
-  static void insertCallback(void* Cls, const char* /*MetricName*/, int64_t TimeSinceEpoch, double Value) {
-    assert(Cls && "External metric does not provide Cls argument");
-    auto& This = *static_cast<RootMetric*>(Cls);
-    // TODO: allow inserting into the sub metrics
-    This.insert(TimeSinceEpoch, Value);
-  }
 };
+
+/// This function insert a time value pair for a specific metric. This function will be provided to metrics to
+/// allow them to push time value pairs.
+/// \arg MetricName The name of the metric for which values are inserted
+/// \arg TimeSinceEpoch The time since epoch of the time value pair
+/// \arg Value The value of the time value pair
+static void insertCallback(void* Cls, const char* /*MetricName*/, int64_t TimeSinceEpoch, double Value) {
+  assert(Cls && "External metric does not provide Cls argument");
+  auto& This = *static_cast<RootMetric*>(Cls);
+  // TODO: allow inserting into the sub metrics
+  This.insert(TimeSinceEpoch, Value);
+}
 
 } // namespace firestarter::measurement

--- a/include/firestarter/Measurement/Metric.hpp
+++ b/include/firestarter/Measurement/Metric.hpp
@@ -41,7 +41,7 @@ using MetricSummaries = std::map<MetricName, Summary>;
 
 struct RootMetric;
 
-/// This class handels the state around a metric. Its name, the contained time value pairs and a mutex to guard them.
+/// This struct handels the state around a metric. Its name, the contained time value pairs and a mutex to guard them.
 struct Metric {
   /// The name of the metric
   std::string Name;
@@ -66,7 +66,7 @@ struct Metric {
                   uint64_t NumThreads) -> Summary;
 };
 
-/// This class handels the state around a leaf metric. Its name, the contained time value pairs and a mutex to guard
+/// This struct handels the state around a leaf metric. Its name, the contained time value pairs and a mutex to guard
 /// them.
 struct LeafMetric : public Metric {
   /// The reference to the root metric that contains this leaf metric.
@@ -82,7 +82,7 @@ struct LeafMetric : public Metric {
   auto metricName() -> MetricName;
 };
 
-/// This class handels the state around a root metric. Its name, the contained time value pairs, a mutex to guard them,
+/// This struct handels the state around a root metric. Its name, the contained time value pairs, a mutex to guard them,
 /// if it is initialized and available and the pointer to the interface to interact with it. Root metrics include
 /// addition leaf-/sub- metrics.
 struct RootMetric : public Metric {
@@ -111,18 +111,21 @@ struct RootMetric : public Metric {
 
   ~RootMetric();
 
-  /// Popuplate the RootMetric object from the C-style MetricInterface.
+  /// Populate the RootMetric object from the C-style MetricInterface.
   /// \arg Metric the refernce to the C-style MetricInterface
+  /// \returns The shared_ptr to the newly created RootMetric
   static auto fromCInterface(MetricInterface& Metric) -> std::shared_ptr<RootMetric>;
 
 #if not(defined(FIRESTARTER_LINK_STATIC)) && defined(linux)
   /// Popuplate the RootMetric object from the C-style MetricInterface provided via a dynamic library.
   /// \arg DylibPath The dynamic library name
+  /// \returns The shared_ptr to the newly created RootMetric
   static auto fromDylib(const std::string& DylibPath) -> std::shared_ptr<RootMetric>;
 #endif
 
   /// Popuplate the RootMetric object from the C-style MetricInterface.
   /// \arg Metric the refernce to the C-style MetricInterface
+  /// \returns The shared_ptr to the newly created RootMetric
   static auto fromStdin(const std::string& MetricName) -> std::shared_ptr<RootMetric>;
 
   /// Initialize the metric. This will set the state to inititialized if successful and insert the optional callback

--- a/include/firestarter/Measurement/Metric.hpp
+++ b/include/firestarter/Measurement/Metric.hpp
@@ -26,6 +26,7 @@
 #include "firestarter/Measurement/Summary.hpp"
 #include "firestarter/Measurement/TimeValue.hpp"
 
+#include <chrono>
 #include <functional>
 #include <map>
 #include <memory>
@@ -53,6 +54,16 @@ struct Metric {
 
   explicit Metric(std::string Name)
       : Name(std::move(Name)) {}
+
+  /// Get the summary of the metric between to time points.
+  /// \arg StartTime The start time of the summarized measurement values
+  /// \arg StopTime The stop time of the summarized measurement values
+  /// \arg MetricType The type of the metric
+  /// \arg NumThreads The number of thread the experiment was run wtih.
+  /// \returns The summary of the values
+  auto getSummary(std::chrono::high_resolution_clock::time_point StartTime,
+                  std::chrono::high_resolution_clock::time_point StopTime, MetricType Type,
+                  uint64_t NumThreads) -> Summary;
 };
 
 /// This class handels the state around a leaf metric. Its name, the contained time value pairs and a mutex to guard

--- a/include/firestarter/Measurement/Metric/IPCEstimate.hpp
+++ b/include/firestarter/Measurement/Metric/IPCEstimate.hpp
@@ -34,7 +34,7 @@ private:
   std::string ErrorString;
 
   /// The saved callback to push the metric value
-  void (*Callback)(void*, const char*, int64_t, double){};
+  void (*Callback)(void*, uint64_t, int64_t, double){};
   /// The saved first argument for the callback
   void* CallbackArg{};
 
@@ -62,10 +62,11 @@ public:
 
   /// The first argument is the function pointer to the callback. The first argument to this function pointer needs to
   /// be filled with the second argument to this function.
-  /// The supplied function pointer needs to be called with the metric name for the second, an unix timestamp (time
-  /// since epoch) for the third and a metric value for the forth argument. This allows the metric to provide values in
-  /// a pushing way in contract to the pulling way of the GetReading function.
-  static auto registerInsertCallback(void (*C)(void*, const char*, int64_t, double), void* Arg) -> int32_t;
+  /// The supplied function pointer needs to be called with either zero in case the metric value is provided or the
+  /// index starting with one of the submetric, an unix timestamp (time since epoch) for the third and a metric value
+  /// for the forth argument. This allows the metric to provide values in a pushing way in contrast to the pulling way
+  /// of the GetReading function.
+  static auto registerInsertCallback(void (*C)(void*, uint64_t, int64_t, double), void* Arg) -> int32_t;
 
   /// Push a value with the current timestamp.
   /// \arg Value The metric value to push.

--- a/include/firestarter/Measurement/Metric/IPCEstimate.hpp
+++ b/include/firestarter/Measurement/Metric/IPCEstimate.hpp
@@ -75,7 +75,7 @@ public:
 /// This metric provdies the ipc estimated based on the estimated number of instructions and the runtime of the high
 /// load loop. The metric value is dependent on the frequency of the processor. It serves as an estimation of the IPC
 /// times the processor frequency.
-static constexpr const MetricInterface IpcEstimateMetric{
+static MetricInterface IpcEstimateMetric{
     /*Name=*/"ipc-estimate",
     /*Type=*/
     {/*Absolute=*/1, /*Accumalative=*/0, /*DivideByThreadCount=*/0, /*InsertCallback=*/1, /*IgnoreStartStopDelta=*/1,

--- a/include/firestarter/Measurement/Metric/IPCEstimate.hpp
+++ b/include/firestarter/Measurement/Metric/IPCEstimate.hpp
@@ -26,9 +26,9 @@
 #include <string>
 
 /// The wrapper for the C interface to the IpcEstimateMetric metric.
-struct IpcEstimateMetricData {
+struct IpcEstimateMetric {
 private:
-  IpcEstimateMetricData() = default;
+  IpcEstimateMetric() = default;
 
   /// The error string of this metric
   std::string ErrorString;
@@ -39,12 +39,12 @@ private:
   void* CallbackArg{};
 
 public:
-  IpcEstimateMetricData(IpcEstimateMetricData const&) = delete;
-  void operator=(IpcEstimateMetricData const&) = delete;
+  IpcEstimateMetric(IpcEstimateMetric const&) = delete;
+  void operator=(IpcEstimateMetric const&) = delete;
 
   /// Get the instance of this metric
-  static auto instance() -> IpcEstimateMetricData& {
-    static IpcEstimateMetricData Instance;
+  static auto instance() -> IpcEstimateMetric& {
+    static IpcEstimateMetric Instance;
     return Instance;
   }
 
@@ -71,24 +71,24 @@ public:
   /// Push a value with the current timestamp.
   /// \arg Value The metric value to push.
   static void insertValue(double Value);
-};
 
-/// This metric provdies the ipc estimated based on the estimated number of instructions and the runtime of the high
-/// load loop. The metric value is dependent on the frequency of the processor. It serves as an estimation of the IPC
-/// times the processor frequency.
-inline static MetricInterface IpcEstimateMetric{
-    /*Name=*/"ipc-estimate",
-    /*Type=*/
-    {/*Absolute=*/1, /*Accumalative=*/0, /*DivideByThreadCount=*/0, /*InsertCallback=*/1, /*IgnoreStartStopDelta=*/1,
-     /*Reserved=*/0},
-    /*Unit=*/"IPC",
-    /*CallbackTime=*/0,
-    /*Callback=*/nullptr,
-    /*Init=*/IpcEstimateMetricData::init,
-    /*Fini=*/IpcEstimateMetricData::fini,
-    /*GetSubmetricNames=*/
-    nullptr,
-    /*GetReading=*/nullptr,
-    /*GetError=*/IpcEstimateMetricData::getError,
-    /*RegisterInsertCallback=*/IpcEstimateMetricData::registerInsertCallback,
+  /// This metric provdies the ipc estimated based on the estimated number of instructions and the runtime of the high
+  /// load loop. The metric value is dependent on the frequency of the processor. It serves as an estimation of the IPC
+  /// times the processor frequency.
+  inline static MetricInterface Metric{
+      /*Name=*/"ipc-estimate",
+      /*Type=*/
+      {/*Absolute=*/1, /*Accumalative=*/0, /*DivideByThreadCount=*/0, /*InsertCallback=*/1, /*IgnoreStartStopDelta=*/1,
+       /*Reserved=*/0},
+      /*Unit=*/"IPC",
+      /*CallbackTime=*/0,
+      /*Callback=*/nullptr,
+      /*Init=*/init,
+      /*Fini=*/fini,
+      /*GetSubmetricNames=*/
+      nullptr,
+      /*GetReading=*/nullptr,
+      /*GetError=*/getError,
+      /*RegisterInsertCallback=*/registerInsertCallback,
+  };
 };

--- a/include/firestarter/Measurement/Metric/IPCEstimate.hpp
+++ b/include/firestarter/Measurement/Metric/IPCEstimate.hpp
@@ -85,6 +85,8 @@ inline static MetricInterface IpcEstimateMetric{
     /*Callback=*/nullptr,
     /*Init=*/IpcEstimateMetricData::init,
     /*Fini=*/IpcEstimateMetricData::fini,
+    /*GetSubmetricNames=*/
+    nullptr,
     /*GetReading=*/nullptr,
     /*GetError=*/IpcEstimateMetricData::getError,
     /*RegisterInsertCallback=*/IpcEstimateMetricData::registerInsertCallback,

--- a/include/firestarter/Measurement/Metric/IPCEstimate.hpp
+++ b/include/firestarter/Measurement/Metric/IPCEstimate.hpp
@@ -75,7 +75,7 @@ public:
 /// This metric provdies the ipc estimated based on the estimated number of instructions and the runtime of the high
 /// load loop. The metric value is dependent on the frequency of the processor. It serves as an estimation of the IPC
 /// times the processor frequency.
-static MetricInterface IpcEstimateMetric{
+inline static MetricInterface IpcEstimateMetric{
     /*Name=*/"ipc-estimate",
     /*Type=*/
     {/*Absolute=*/1, /*Accumalative=*/0, /*DivideByThreadCount=*/0, /*InsertCallback=*/1, /*IgnoreStartStopDelta=*/1,

--- a/include/firestarter/Measurement/Metric/Perf.hpp
+++ b/include/firestarter/Measurement/Metric/Perf.hpp
@@ -27,9 +27,9 @@
 #include <string>
 
 /// The wrapper for the C interface to the PerfIpcMetric and PerfFreqMetric metric.
-class PerfMetricData {
+class PerfMetric {
 private:
-  PerfMetricData() = default;
+  PerfMetric() = default;
 
   static const constexpr char* PerfEventParanoidFile = "/proc/sys/kernel/perf_event_paranoid";
 
@@ -72,12 +72,12 @@ private:
   static auto getReading(double* IpcValue, double* FreqValue) -> int32_t;
 
 public:
-  PerfMetricData(PerfMetricData const&) = delete;
-  void operator=(PerfMetricData const&) = delete;
+  PerfMetric(PerfMetric const&) = delete;
+  void operator=(PerfMetric const&) = delete;
 
   /// Get the instance of this metric
-  static auto instance() -> PerfMetricData& {
-    static PerfMetricData Instance;
+  static auto instance() -> PerfMetric& {
+    static PerfMetric Instance;
     return Instance;
   }
 
@@ -111,40 +111,40 @@ public:
   /// Get error in case return code not being EXIT_SUCCESS.
   /// \returns The error string.
   static auto getError() -> const char*;
-};
 
-/// This metric provides IPC measurement of the programm and all associated threads.
-inline static MetricInterface PerfIpcMetric{
-    /*Name=*/"perf-ipc",
-    /*Type=*/
-    {/*Absolute=*/1, /*Accumalative=*/0, /*DivideByThreadCount=*/0, /*InsertCallback=*/0, /*IgnoreStartStopDelta=*/0,
-     /*Reserved=*/0},
-    /*Unit=*/"IPC",
-    /*CallbackTime=*/0,
-    /*Callback=*/nullptr,
-    /*Init=*/PerfMetricData::init,
-    /*Fini=*/PerfMetricData::fini,
-    /*GetSubmetricNames=*/
-    nullptr,
-    /*GetReading=*/PerfMetricData::getReadingIpc,
-    /*GetError=*/PerfMetricData::getError,
-    /*RegisterInsertCallback=*/nullptr,
-};
+  /// This metric provides IPC measurement of the programm and all associated threads.
+  inline static MetricInterface PerfIpcMetric{
+      /*Name=*/"perf-ipc",
+      /*Type=*/
+      {/*Absolute=*/1, /*Accumalative=*/0, /*DivideByThreadCount=*/0, /*InsertCallback=*/0, /*IgnoreStartStopDelta=*/0,
+       /*Reserved=*/0},
+      /*Unit=*/"IPC",
+      /*CallbackTime=*/0,
+      /*Callback=*/nullptr,
+      /*Init=*/init,
+      /*Fini=*/fini,
+      /*GetSubmetricNames=*/
+      nullptr,
+      /*GetReading=*/getReadingIpc,
+      /*GetError=*/getError,
+      /*RegisterInsertCallback=*/nullptr,
+  };
 
-/// This metric provides frequency measurement on the CPUs used to execute the program on.
-inline static MetricInterface PerfFreqMetric{
-    /*Name=*/"perf-freq",
-    /*Type=*/
-    {/*Absolute=*/0, /*Accumalative=*/1, /*DivideByThreadCount=*/1, /*InsertCallback=*/0, /*IgnoreStartStopDelta=*/0,
-     /*Reserved=*/0},
-    /*Unit=*/"GHz",
-    /*CallbackTime=*/0,
-    /*Callback=*/nullptr,
-    /*Init=*/PerfMetricData::init,
-    /*Fini=*/PerfMetricData::fini,
-    /*GetSubmetricNames=*/
-    nullptr,
-    /*GetReading=*/PerfMetricData::getReadingFreq,
-    /*GetError=*/PerfMetricData::getError,
-    /*RegisterInsertCallback=*/nullptr,
+  /// This metric provides frequency measurement on the CPUs used to execute the program on.
+  inline static MetricInterface PerfFreqMetric{
+      /*Name=*/"perf-freq",
+      /*Type=*/
+      {/*Absolute=*/0, /*Accumalative=*/1, /*DivideByThreadCount=*/1, /*InsertCallback=*/0, /*IgnoreStartStopDelta=*/0,
+       /*Reserved=*/0},
+      /*Unit=*/"GHz",
+      /*CallbackTime=*/0,
+      /*Callback=*/nullptr,
+      /*Init=*/init,
+      /*Fini=*/fini,
+      /*GetSubmetricNames=*/
+      nullptr,
+      /*GetReading=*/getReadingFreq,
+      /*GetError=*/getError,
+      /*RegisterInsertCallback=*/nullptr,
+  };
 };

--- a/include/firestarter/Measurement/Metric/Perf.hpp
+++ b/include/firestarter/Measurement/Metric/Perf.hpp
@@ -95,14 +95,18 @@ public:
   static auto valueFromId(struct ReadFormat* Reader, uint64_t Id) -> uint64_t;
 
   /// Get a reading of the perf-ipc metric.
-  /// \arg Value The pointer to which the value will be saved.
+  /// \arg Values The memory array to which double values are saved. The index zero contains the root metric. The values
+  /// one and up are used to select the specific submetric.
+  /// \arg NumElems The number of elements in the double array.
   /// \returns EXIT_SUCCESS if we got a new value.
-  static auto getReadingIpc(double* Value) -> int32_t;
+  static auto getReadingIpc(double* Value, uint64_t NumElems) -> int32_t;
 
   /// Get a reading of the perf-freq metric.
-  /// \arg Value The pointer to which the value will be saved.
+  /// \arg Values The memory array to which double values are saved. The index zero contains the root metric. The values
+  /// one and up are used to select the specific submetric.
+  /// \arg NumElems The number of elements in the double array.
   /// \returns EXIT_SUCCESS if we got a new value.
-  static auto getReadingFreq(double* Value) -> int32_t;
+  static auto getReadingFreq(double* Value, uint64_t NumElems) -> int32_t;
 
   /// Get error in case return code not being EXIT_SUCCESS.
   /// \returns The error string.

--- a/include/firestarter/Measurement/Metric/Perf.hpp
+++ b/include/firestarter/Measurement/Metric/Perf.hpp
@@ -110,7 +110,7 @@ public:
 };
 
 /// This metric provides IPC measurement of the programm and all associated threads.
-static MetricInterface PerfIpcMetric{
+inline static MetricInterface PerfIpcMetric{
     /*Name=*/"perf-ipc",
     /*Type=*/
     {/*Absolute=*/1, /*Accumalative=*/0, /*DivideByThreadCount=*/0, /*InsertCallback=*/0, /*IgnoreStartStopDelta=*/0,
@@ -126,7 +126,7 @@ static MetricInterface PerfIpcMetric{
 };
 
 /// This metric provides frequency measurement on the CPUs used to execute the program on.
-static MetricInterface PerfFreqMetric{
+inline static MetricInterface PerfFreqMetric{
     /*Name=*/"perf-freq",
     /*Type=*/
     {/*Absolute=*/0, /*Accumalative=*/1, /*DivideByThreadCount=*/1, /*InsertCallback=*/0, /*IgnoreStartStopDelta=*/0,

--- a/include/firestarter/Measurement/Metric/Perf.hpp
+++ b/include/firestarter/Measurement/Metric/Perf.hpp
@@ -110,7 +110,7 @@ public:
 };
 
 /// This metric provides IPC measurement of the programm and all associated threads.
-static constexpr const MetricInterface PerfIpcMetric{
+static MetricInterface PerfIpcMetric{
     /*Name=*/"perf-ipc",
     /*Type=*/
     {/*Absolute=*/1, /*Accumalative=*/0, /*DivideByThreadCount=*/0, /*InsertCallback=*/0, /*IgnoreStartStopDelta=*/0,
@@ -126,7 +126,7 @@ static constexpr const MetricInterface PerfIpcMetric{
 };
 
 /// This metric provides frequency measurement on the CPUs used to execute the program on.
-static constexpr const MetricInterface PerfFreqMetric{
+static MetricInterface PerfFreqMetric{
     /*Name=*/"perf-freq",
     /*Type=*/
     {/*Absolute=*/0, /*Accumalative=*/1, /*DivideByThreadCount=*/1, /*InsertCallback=*/0, /*IgnoreStartStopDelta=*/0,

--- a/include/firestarter/Measurement/Metric/Perf.hpp
+++ b/include/firestarter/Measurement/Metric/Perf.hpp
@@ -120,6 +120,8 @@ inline static MetricInterface PerfIpcMetric{
     /*Callback=*/nullptr,
     /*Init=*/PerfMetricData::init,
     /*Fini=*/PerfMetricData::fini,
+    /*GetSubmetricNames=*/
+    nullptr,
     /*GetReading=*/PerfMetricData::getReadingIpc,
     /*GetError=*/PerfMetricData::getError,
     /*RegisterInsertCallback=*/nullptr,
@@ -136,6 +138,8 @@ inline static MetricInterface PerfFreqMetric{
     /*Callback=*/nullptr,
     /*Init=*/PerfMetricData::init,
     /*Fini=*/PerfMetricData::fini,
+    /*GetSubmetricNames=*/
+    nullptr,
     /*GetReading=*/PerfMetricData::getReadingFreq,
     /*GetError=*/PerfMetricData::getError,
     /*RegisterInsertCallback=*/nullptr,

--- a/include/firestarter/Measurement/Metric/RAPL.hpp
+++ b/include/firestarter/Measurement/Metric/RAPL.hpp
@@ -92,7 +92,7 @@ public:
 
 /// This metric provides power measurements through the RAPL interface. Either psys measurement is choosen or if this is
 /// not available the sum of packages and drams.
-static MetricInterface RaplMetric{
+inline static MetricInterface RaplMetric{
     /*Name=*/"sysfs-powercap-rapl",
     /*Type=*/
     {/*Absolute=*/0, /*Accumalative=*/1, /*DivideByThreadCount=*/0, /*InsertCallback=*/0, /*IgnoreStartStopDelta=*/0,

--- a/include/firestarter/Measurement/Metric/RAPL.hpp
+++ b/include/firestarter/Measurement/Metric/RAPL.hpp
@@ -121,7 +121,7 @@ private:
     };
 
     /// Get the name of this metric
-    auto name() -> auto& { return Name; }
+    auto name() -> const auto& { return Name; }
 
     /// Read the RAPL counter and update the internal state
     void read() {

--- a/include/firestarter/Measurement/Metric/RAPL.hpp
+++ b/include/firestarter/Measurement/Metric/RAPL.hpp
@@ -188,9 +188,11 @@ public:
   static auto getSubmetricNames() -> const char** { return instance().SubmetricNames.data(); }
 
   /// Get a reading of the sysfs-powercap-rapl metric.
-  /// \arg Value The pointer to which the value will be saved.
+  /// \arg Values The memory array to which double values are saved. The index zero contains the root metric. The values
+  /// one and up are used to select the specific submetric.
+  /// \arg NumElems The number of elements in the double array.
   /// \returns EXIT_SUCCESS if we got a new value.
-  static auto getReading(double* Value) -> int32_t;
+  static auto getReading(double* Value, uint64_t NumElems) -> int32_t;
 
   /// Get error in case return code not being EXIT_SUCCESS.
   /// \returns The error string.

--- a/include/firestarter/Measurement/Metric/RAPL.hpp
+++ b/include/firestarter/Measurement/Metric/RAPL.hpp
@@ -31,7 +31,7 @@
 #include <vector>
 
 /// The wrapper for the C interface to the RaplMetric metric.
-class RaplMetricData {
+class RaplMetric {
 private:
   /// Datastructure to hold the path of the sysfs rapl entry, the last reading (improtant to detect overflows), the
   /// counter of the number of overflows and the maximum value that the reading will have.
@@ -153,15 +153,15 @@ private:
   /// The null terminated vector of submetric names.
   std::vector<const char*> SubmetricNames = {nullptr};
 
-  RaplMetricData() = default;
+  RaplMetric() = default;
 
 public:
-  RaplMetricData(RaplMetricData const&) = delete;
-  void operator=(RaplMetricData const&) = delete;
+  RaplMetric(RaplMetric const&) = delete;
+  void operator=(RaplMetric const&) = delete;
 
   /// Get the instance of this metric
-  static auto instance() -> RaplMetricData& {
-    static RaplMetricData Instance;
+  static auto instance() -> RaplMetric& {
+    static RaplMetric Instance;
     return Instance;
   }
 
@@ -192,23 +192,23 @@ public:
   /// This function should be called every 30s. It will make shure that we do not miss an overflow of a counter and
   /// therefore get a wrong reading.
   static void callback();
-};
 
-/// This metric provides power measurements through the RAPL interface. Either psys measurement is choosen or if this is
-/// not available the sum of packages and drams.
-inline static MetricInterface RaplMetric{
-    /*Name=*/"sysfs-powercap-rapl",
-    /*Type=*/
-    {/*Absolute=*/0, /*Accumalative=*/1, /*DivideByThreadCount=*/0, /*InsertCallback=*/0, /*IgnoreStartStopDelta=*/0,
-     /*Reserved=*/0},
-    /*Unit=*/"J",
-    /*CallbackTime=*/30000000,
-    /*Callback=*/RaplMetricData::callback,
-    /*Init=*/RaplMetricData::init,
-    /*Fini=*/RaplMetricData::fini,
-    /*GetSubmetricNames=*/
-    RaplMetricData::getSubmetricNames,
-    /*GetReading=*/RaplMetricData::getReading,
-    /*GetError=*/RaplMetricData::getError,
-    /*RegisterInsertCallback=*/nullptr,
+  /// This metric provides power measurements through the RAPL interface. Either psys measurement is choosen or if this
+  /// is not available the sum of packages and drams.
+  inline static MetricInterface Metric{
+      /*Name=*/"sysfs-powercap-rapl",
+      /*Type=*/
+      {/*Absolute=*/0, /*Accumalative=*/1, /*DivideByThreadCount=*/0, /*InsertCallback=*/0, /*IgnoreStartStopDelta=*/0,
+       /*Reserved=*/0},
+      /*Unit=*/"J",
+      /*CallbackTime=*/30000000,
+      /*Callback=*/callback,
+      /*Init=*/init,
+      /*Fini=*/fini,
+      /*GetSubmetricNames=*/
+      getSubmetricNames,
+      /*GetReading=*/getReading,
+      /*GetError=*/getError,
+      /*RegisterInsertCallback=*/nullptr,
+  };
 };

--- a/include/firestarter/Measurement/Metric/RAPL.hpp
+++ b/include/firestarter/Measurement/Metric/RAPL.hpp
@@ -68,20 +68,11 @@ private:
         std::getline(NameStream, ParsedName);
       }
 
-      std::string DevicePath;
-
-      {
-        std::ifstream DeviceStream(Path + "/device");
-        if (!DeviceStream.good()) {
-          // else return the name
-          return Name;
-        }
-
-        std::getline(DeviceStream, DevicePath);
-      }
-
       // Got to the device that is set in the path and call the function on it.
-      return getNameRecursive(DevicePath, ParsedName + "-" + Name);
+      if (!Name.empty()) {
+        ParsedName += "-" + Name;
+      }
+      return getNameRecursive(Path + "/device", ParsedName);
     };
 
   public:
@@ -98,14 +89,14 @@ private:
       }
 
       std::stringstream EnergyUjPath;
-      EnergyUjPath << Path << "/energy_uj";
+      EnergyUjPath << this->Path << "/energy_uj";
       std::ifstream EnergyReadingStream(EnergyUjPath.str());
       if (!EnergyReadingStream.good()) {
         throw std::runtime_error("Could not read energy_uj");
       }
 
       std::stringstream MaxEnergyUjRangePath;
-      MaxEnergyUjRangePath << Path << "/max_energy_range_uj";
+      MaxEnergyUjRangePath << this->Path << "/max_energy_range_uj";
       std::ifstream MaxEnergyReadingStream(MaxEnergyUjRangePath.str());
       if (!MaxEnergyReadingStream.good()) {
         throw std::runtime_error("Could not read max_energy_range_uj");

--- a/include/firestarter/Measurement/Metric/RAPL.hpp
+++ b/include/firestarter/Measurement/Metric/RAPL.hpp
@@ -160,7 +160,7 @@ private:
   std::vector<std::shared_ptr<ReaderDef>> AccumulateReaders;
 
   /// The null terminated vector of submetric names.
-  std::vector<char*> SubmetricNames = {nullptr};
+  std::vector<const char*> SubmetricNames = {nullptr};
 
   RaplMetricData() = default;
 
@@ -185,7 +185,7 @@ public:
   /// Get a vector of submetric names. This is required to know the name of a submetric that is just described via an
   /// index throughout this metric interface.
   /// \returns The NULL terminated array of submetric names (char *)
-  static auto getSubmetricNames() -> char** { return instance().SubmetricNames.data(); }
+  static auto getSubmetricNames() -> const char** { return instance().SubmetricNames.data(); }
 
   /// Get a reading of the sysfs-powercap-rapl metric.
   /// \arg Value The pointer to which the value will be saved.

--- a/include/firestarter/Measurement/Metric/RAPL.hpp
+++ b/include/firestarter/Measurement/Metric/RAPL.hpp
@@ -82,7 +82,7 @@ private:
     explicit ReaderDef(std::string Path)
         : Path(std::move(Path)) {
 
-      Name = getNameRecursive(Path);
+      Name = getNameRecursive(this->Path);
       if (Name.empty()) {
         // an error opening the file occured
         throw std::invalid_argument("Not a valid metric");

--- a/include/firestarter/Measurement/Metric/RAPL.hpp
+++ b/include/firestarter/Measurement/Metric/RAPL.hpp
@@ -92,7 +92,7 @@ public:
 
 /// This metric provides power measurements through the RAPL interface. Either psys measurement is choosen or if this is
 /// not available the sum of packages and drams.
-static constexpr const MetricInterface RaplMetric{
+static MetricInterface RaplMetric{
     /*Name=*/"sysfs-powercap-rapl",
     /*Type=*/
     {/*Absolute=*/0, /*Accumalative=*/1, /*DivideByThreadCount=*/0, /*InsertCallback=*/0, /*IgnoreStartStopDelta=*/0,

--- a/include/firestarter/Measurement/MetricInterface.h
+++ b/include/firestarter/Measurement/MetricInterface.h
@@ -77,6 +77,12 @@ typedef struct {
   /// \returns EXIT_SUCCESS on success.
   int32_t (*Fini)();
 
+  /// Get a vector of submetric names. This is required to know the name of a submetric that is just described via an
+  /// index throughout this metric interface.
+  /// This function ptr may be NULL in case the metric does not support submetrics.
+  /// \returns The NULL terminated array of submetric names (char *)
+  char** (*GetSubmetricNames)();
+
   /// Get a reading of the metric. Set this function pointer to null if MetricType::InsertCallback is specified in the
   /// Type.
   /// \arg Value The pointer to which the value will be saved.

--- a/include/firestarter/Measurement/MetricInterface.h
+++ b/include/firestarter/Measurement/MetricInterface.h
@@ -34,6 +34,10 @@ extern "C" {
 
 /// Describe the type of the metric and how values need to be accumulated. Per default metrics are of pulling type where
 /// FIRESTARTER will pull the values through the GetReading function.
+
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define ROOT_METRIC_INDEX 0
+
 typedef struct {
   uint32_t
       /// Set this to 1 if the metric values provided are absolute.
@@ -97,10 +101,11 @@ typedef struct {
   /// and the first argument to this callback.
   /// The first argument is the function pointer to the callback. The first argument to this function pointer needs to
   /// be filled with the second argument to this function.
-  /// The supplied function pointer needs to be called with the metric name for the second, an unix timestamp (time
-  /// since epoch) for the third and a metric value for the forth argument. This allows the metric to provide values in
-  /// a pushing way in contract to the pulling way of the GetReading function.
-  int32_t (*RegisterInsertCallback)(void (*)(void*, const char*, int64_t, double), void*);
+  /// The supplied function pointer needs to be called with either zero in case the metric value is provided or the
+  /// index starting with one of the submetric, an unix timestamp (time since epoch) for the third and a metric value
+  /// for the forth argument. This allows the metric to provide values in a pushing way in contrast to the pulling way
+  /// of the GetReading function.
+  int32_t (*RegisterInsertCallback)(void (*)(void*, uint64_t, int64_t, double), void*);
 
 } MetricInterface;
 // NOLINTEND(modernize-use-using)

--- a/include/firestarter/Measurement/MetricInterface.h
+++ b/include/firestarter/Measurement/MetricInterface.h
@@ -89,9 +89,11 @@ typedef struct {
 
   /// Get a reading of the metric. Set this function pointer to null if MetricType::InsertCallback is specified in the
   /// Type.
-  /// \arg Value The pointer to which the value will be saved.
+  /// \arg Values The memory array to which double values are saved. The index zero contains the root metric. The values
+  /// one and up are used to select the specific submetric.
+  /// \arg NumElems The number of elements in the double array.
   /// \returns EXIT_SUCCESS if we got a new value.
-  int32_t (*GetReading)(double* Value);
+  int32_t (*GetReading)(double* Value, uint64_t NumElems);
 
   /// Get error in case return code not being EXIT_SUCCESS.
   /// \returns The error string.

--- a/include/firestarter/Measurement/MetricInterface.h
+++ b/include/firestarter/Measurement/MetricInterface.h
@@ -81,7 +81,7 @@ typedef struct {
   /// index throughout this metric interface.
   /// This function ptr may be NULL in case the metric does not support submetrics.
   /// \returns The NULL terminated array of submetric names (char *)
-  char** (*GetSubmetricNames)();
+  const char** (*GetSubmetricNames)();
 
   /// Get a reading of the metric. Set this function pointer to null if MetricType::InsertCallback is specified in the
   /// Type.

--- a/include/firestarter/Measurement/Summary.hpp
+++ b/include/firestarter/Measurement/Summary.hpp
@@ -25,7 +25,6 @@
 #include "firestarter/Measurement/TimeValue.hpp"
 
 #include <chrono>
-#include <nlohmann/json.hpp>
 #include <vector>
 
 namespace firestarter::measurement {

--- a/include/firestarter/Measurement/TimeValue.hpp
+++ b/include/firestarter/Measurement/TimeValue.hpp
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <chrono>
+#include <tuple>
 
 namespace firestarter::measurement {
 
@@ -32,6 +33,10 @@ struct TimeValue {
   constexpr TimeValue(std::chrono::high_resolution_clock::time_point Time, double Value)
       : Time(Time)
       , Value(Value){};
+
+  friend auto operator==(const TimeValue& Lhs, const TimeValue& Rhs) -> bool {
+    return std::tie(Lhs.Time, Lhs.Value) == std::tie(Rhs.Time, Lhs.Value);
+  }
 
   std::chrono::high_resolution_clock::time_point Time;
   double Value{};

--- a/include/firestarter/Measurement/TimeValue.hpp
+++ b/include/firestarter/Measurement/TimeValue.hpp
@@ -34,8 +34,8 @@ struct TimeValue {
       : Time(Time)
       , Value(Value){};
 
-  friend auto operator==(const TimeValue& Lhs, const TimeValue& Rhs) -> bool {
-    return std::tie(Lhs.Time, Lhs.Value) == std::tie(Rhs.Time, Lhs.Value);
+  auto operator==(const TimeValue& Other) const -> bool {
+    return std::tie(Time, Value) == std::tie(Other.Time, Other.Value);
   }
 
   std::chrono::high_resolution_clock::time_point Time;

--- a/include/firestarter/Optimizer/History.hpp
+++ b/include/firestarter/Optimizer/History.hpp
@@ -214,6 +214,7 @@ public:
         for (auto const& Metric : OptimizationMetrics) {
           auto Width = ColumnWidth[Metric];
 
+          auto IsSameMetric = [&Metric](const auto& NameValuePair) { return NameValuePair.first.isSameMetric(Metric); };
           auto FitnessOfMetric = std::find_if(Fitness.cbegin(), Fitness.cend(), IsSameMetric);
 
           assert(FitnessOfMetric != Fitness.cend());

--- a/include/firestarter/Optimizer/History.hpp
+++ b/include/firestarter/Optimizer/History.hpp
@@ -21,8 +21,10 @@
 
 #pragma once
 
-#include "firestarter/Json/Summary.hpp" // IWYU pragma: keep
+#include "firestarter/Json/MetricName.hpp" // IWYU pragma: keep
+#include "firestarter/Json/Summary.hpp"    // IWYU pragma: keep
 #include "firestarter/Logging/Log.hpp"
+#include "firestarter/Measurement/Metric.hpp"
 #include "firestarter/Measurement/Summary.hpp"
 #include "firestarter/Optimizer/Individual.hpp"
 #include "firestarter/WindowsCompat.hpp" // IWYU pragma: keep
@@ -78,15 +80,14 @@ private:
   /// The vector of individuals that have been evaluated. This vector has the same size as F.
   inline static std::vector<Individual> X = {};
   /// The vector of metric summaries associated to the evaluated individuals. This vector has the same size as X.
-  inline static std::vector<std::map<std::string, firestarter::measurement::Summary>> F = {};
+  inline static std::vector<measurement::MetricSummaries> F = {};
   // NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
 
 public:
   /// Append an evaluated individual to the history.
   /// \arg Ind The individual to add.
   /// \arg Metric The metric summaries for this individual.
-  static void append(std::vector<unsigned> const& Ind,
-                     std::map<std::string, firestarter::measurement::Summary> const& Metric) {
+  static void append(std::vector<unsigned> const& Ind, measurement::MetricSummaries const& Metric) {
     X.push_back(Ind);
     F.push_back(Metric);
   }
@@ -94,8 +95,7 @@ public:
   /// Loopup an indiviudal in the history and return the metric summaries if it is in the history.
   /// \arg Individual The individual which may already be evaluated.
   /// \returns The metric summaries if the individual is in the history or std::nullopt otherwise.
-  static auto find(std::vector<unsigned> const& Individual)
-      -> std::optional<std::map<std::string, firestarter::measurement::Summary>> {
+  static auto find(std::vector<unsigned> const& Individual) -> std::optional<measurement::MetricSummaries> {
     auto FindEqual = [&Individual](auto const& Ind) { return Ind == Individual; };
     auto Ind = std::find_if(X.begin(), X.end(), FindEqual);
     if (Ind == X.end()) {
@@ -109,36 +109,34 @@ public:
   /// metric.
   /// \arg OptimizationMetrics The metrics for which the best individual should be printed.
   /// \arg PayloadItems The instruction of the associated instruction groups used in the optimization.
-  static void printBest(std::vector<std::string> const& OptimizationMetrics,
+  static void printBest(std::vector<MetricName> const& OptimizationMetrics,
                         std::vector<std::string> const& PayloadItems) {
     // TODO(Issue #76): print paretto front
 
     // print the best 20 individuals for each metric in a format
     // where the user can give it to --run-instruction-groups directly
-    std::map<std::string, std::size_t> ColumnWidth;
+    std::map<MetricName, std::size_t> ColumnWidth;
 
     for (auto const& Metric : OptimizationMetrics) {
-      ColumnWidth[Metric] = (std::max)(Metric.size(), MinColumnWidth);
-      firestarter::log::trace() << Metric << ": " << ColumnWidth[Metric];
+      ColumnWidth[Metric] = (std::max)(Metric.toString().size(), MinColumnWidth);
+      firestarter::log::trace() << Metric.toString() << ": " << ColumnWidth[Metric];
     }
 
     for (auto const& Metric : OptimizationMetrics) {
-      using SummaryMap = std::map<std::string, firestarter::measurement::Summary>;
-      auto CompareIndividual = [&Metric](SummaryMap const& MapA, SummaryMap const& MapB) {
-        auto SummaryA = MapA.find(Metric);
-        auto SummaryB = MapB.find(Metric);
+      auto IsSameMetric = [&Metric](const auto& NameValuePair) { return NameValuePair.first.isSameMetric(Metric); };
 
-        if (SummaryA == MapA.end() || SummaryB == MapB.end()) {
-          SummaryA = MapA.find(Metric.substr(1));
-          SummaryB = MapB.find(Metric.substr(1));
-          assert(SummaryA != MapA.end());
-          assert(SummaryB != MapB.end());
-          return SummaryA->second.Average < SummaryB->second.Average;
+      auto CompareIndividual = [&Metric, &IsSameMetric](measurement::MetricSummaries const& Lhs,
+                                                        measurement::MetricSummaries const& Rhs) {
+        auto SummaryLhs = std::find_if(Lhs.cbegin(), Lhs.cend(), IsSameMetric);
+        auto SummaryRhs = std::find_if(Lhs.cbegin(), Lhs.cend(), IsSameMetric);
+
+        assert(SummaryLhs != Lhs.cend());
+        assert(SummaryRhs != Rhs.cend());
+
+        if (!Metric.inverted()) {
+          return SummaryLhs->second.Average > SummaryRhs->second.Average;
         }
-
-        assert(SummaryA != MapA.end());
-        assert(SummaryB != MapB.end());
-        return SummaryA->second.Average > SummaryB->second.Average;
+        return SummaryLhs->second.Average > SummaryRhs->second.Average;
       };
 
       auto Perm = sortPermutation(F, CompareIndividual);
@@ -193,15 +191,15 @@ public:
         FirstLine << " | ";
         SecondLine << "---";
 
-        FirstLine << Metric;
-        padding(FirstLine, Width, Metric.size(), ' ');
+        FirstLine << Metric.toString();
+        padding(FirstLine, Width, Metric.toString().size(), ' ');
         padding(SecondLine, Width, 0, '-');
       }
 
       std::stringstream Ss;
 
-      Ss << "\n Best individuals sorted by metric " << Metric << " "
-         << ((Metric[0] == '-') ? "ascending" : "descending") << ":\n"
+      Ss << "\n Best individuals sorted by metric " << Metric.toString() << " "
+         << (Metric.inverted() ? "ascending" : "descending") << ":\n"
          << FirstLine.str() << "\n"
          << SecondLine.str() << "\n";
 
@@ -215,19 +213,12 @@ public:
 
         for (auto const& Metric : OptimizationMetrics) {
           auto Width = ColumnWidth[Metric];
-          std::string Value;
 
-          auto FitnessOfMetric = Fitness.find(Metric);
-          auto InvertedMetric = Metric.substr(1);
-          auto FitnessOfInvertedMetric = Fitness.find(InvertedMetric);
+          auto FitnessOfMetric = std::find_if(Fitness.cbegin(), Fitness.cend(), IsSameMetric);
 
-          if (FitnessOfMetric != Fitness.end()) {
-            Value = std::to_string(FitnessOfMetric->second.Average);
-          } else if (FitnessOfInvertedMetric != Fitness.end()) {
-            Value = std::to_string(FitnessOfInvertedMetric->second.Average);
-          } else {
-            assert(false);
-          }
+          assert(FitnessOfMetric != Fitness.cend());
+
+          const auto Value = std::to_string(FitnessOfMetric->second.Average);
 
           Ss << " | " << Value;
           padding(Ss, Width, Value.size(), ' ');

--- a/include/firestarter/Optimizer/History.hpp
+++ b/include/firestarter/Optimizer/History.hpp
@@ -128,7 +128,7 @@ public:
       auto CompareIndividual = [&Metric, &IsSameMetric](measurement::MetricSummaries const& Lhs,
                                                         measurement::MetricSummaries const& Rhs) {
         auto SummaryLhs = std::find_if(Lhs.cbegin(), Lhs.cend(), IsSameMetric);
-        auto SummaryRhs = std::find_if(Lhs.cbegin(), Lhs.cend(), IsSameMetric);
+        auto SummaryRhs = std::find_if(Rhs.cbegin(), Rhs.cend(), IsSameMetric);
 
         assert(SummaryLhs != Lhs.cend());
         assert(SummaryRhs != Rhs.cend());
@@ -136,7 +136,7 @@ public:
         if (!Metric.inverted()) {
           return SummaryLhs->second.Average > SummaryRhs->second.Average;
         }
-        return SummaryLhs->second.Average > SummaryRhs->second.Average;
+        return SummaryLhs->second.Average < SummaryRhs->second.Average;
       };
 
       auto Perm = sortPermutation(F, CompareIndividual);

--- a/include/firestarter/Optimizer/Problem.hpp
+++ b/include/firestarter/Optimizer/Problem.hpp
@@ -21,11 +21,10 @@
 
 #pragma once
 
-#include "firestarter/Measurement/Summary.hpp"
+#include "firestarter/Measurement/Metric.hpp"
 #include "firestarter/Optimizer/Individual.hpp"
 
 #include <cstring>
-#include <map>
 #include <tuple>
 #include <vector>
 
@@ -45,14 +44,13 @@ public:
   /// summary. This function will increment the fevals.
   /// \arg Individual The individual that should be evaluated.
   /// \returns A map from metric name to the summary of this metric for the specific individual
-  virtual auto metrics(Individual const& Individual) -> std::map<std::string, firestarter::measurement::Summary> = 0;
+  virtual auto metrics(Individual const& Individual) -> measurement::MetricSummaries = 0;
 
   /// Convert the result of one evaluation into a fitness (vector of doubles) for the supplied summaries
   /// \arg Summaries The summaries of one evaluation.
   /// \returns The fitness vector derived from the summaries. The size of this vector is equal to the number of
   /// objectives.
-  [[nodiscard]] virtual auto
-  fitness(std::map<std::string, firestarter::measurement::Summary> const& Summaries) const -> std::vector<double> = 0;
+  [[nodiscard]] virtual auto fitness(measurement::MetricSummaries const& Summaries) const -> std::vector<double> = 0;
 
   /// Get the bounds of the problem. For each dimension a min and max value is supplied.
   /// \return The min and max bound per dimension.

--- a/include/firestarter/Optimizer/Problem/CLIArgumentProblem.hpp
+++ b/include/firestarter/Optimizer/Problem/CLIArgumentProblem.hpp
@@ -28,7 +28,6 @@
 #include <cassert>
 #include <cmath>
 #include <functional>
-#include <stdexcept>
 #include <thread>
 #include <tuple>
 #include <utility>

--- a/include/firestarter/Optimizer/Problem/CLIArgumentProblem.hpp
+++ b/include/firestarter/Optimizer/Problem/CLIArgumentProblem.hpp
@@ -27,6 +27,7 @@
 
 #include <cassert>
 #include <functional>
+#include <stdexcept>
 #include <thread>
 #include <tuple>
 #include <utility>
@@ -44,7 +45,7 @@ private:
   std::shared_ptr<firestarter::measurement::MeasurementWorker> MeasurementWorker;
   /// The metrics that are used in the optimization. They may have a dash at the start to allow them to be changed from
   /// maximization to minimization.
-  std::vector<std::string> Metrics;
+  std::vector<MetricName> Metrics;
   /// The duration of the measurement.
   std::chrono::seconds Timeout;
   /// The time to skip from the measurement start
@@ -68,7 +69,7 @@ public:
   /// \arg Instructions The vector of instruction that is used in the optimization for the payload.
   CLIArgumentProblem(std::function<void(const firestarter::InstructionGroups&)>&& ChangePayloadFunction,
                      std::shared_ptr<firestarter::measurement::MeasurementWorker> MeasurementWorker,
-                     std::vector<std::string> const& Metrics, std::chrono::seconds Timeout,
+                     std::vector<MetricName> const& Metrics, std::chrono::seconds Timeout,
                      std::chrono::milliseconds StartDelta, std::chrono::milliseconds StopDelta,
                      std::vector<std::string> Instructions)
       : ChangePayloadFunction(std::move(ChangePayloadFunction))
@@ -86,8 +87,7 @@ public:
   /// Evaluate the given individual by switching the current payload, doing the measurement and returning the results.
   /// \arg Individual The indivudal that should be measured.
   /// \returns The map from all metrics to their respective summaries for the measured individual.
-  auto metrics(std::vector<unsigned> const& Individual)
-      -> std::map<std::string, firestarter::measurement::Summary> override {
+  auto metrics(std::vector<unsigned> const& Individual) -> measurement::MetricSummaries override {
     // increment evaluation idx
     incrementFevals();
 
@@ -118,27 +118,25 @@ public:
   /// starts with a dash ('-').
   /// \arg Summaries The metric values for all metrics for an individual
   /// \return The vector containing the fitness for that metrics that are used in the optimization.
-  [[nodiscard]] auto fitness(std::map<std::string, firestarter::measurement::Summary> const& Summaries) const
-      -> std::vector<double> override {
+  [[nodiscard]] auto fitness(measurement::MetricSummaries const& Summaries) const -> std::vector<double> override {
     std::vector<double> Values = {};
 
     for (auto const& MetricName : Metrics) {
-      auto FindName = [MetricName](auto const& Summary) {
-        auto InvertedName = "-" + Summary.first;
-        return MetricName == Summary.first || MetricName == InvertedName;
-      };
+      auto It = std::find_if(Summaries.cbegin(), Summaries.cend(), [&MetricName](const auto& NameValuePair) {
+        return NameValuePair.first.isSameMetric(MetricName);
+      });
 
-      auto It = std::find_if(Summaries.begin(), Summaries.end(), FindName);
-
-      if (It == Summaries.end()) {
-        continue;
+      // Metric name not found
+      if (It == Summaries.cend()) {
+        throw std::invalid_argument("CLIArgumentProblem fitness: Metric " + MetricName.toString() +
+                                    " not found in supplied MetricSummaries.");
       }
 
       // round to two decimal places after the comma
       auto Value = std::round(It->second.Average * 100.0) / 100.0;
 
       // invert metric
-      if (MetricName[0] == '-') {
+      if (MetricName.inverted()) {
         Value *= -1.0;
       }
 

--- a/include/firestarter/Optimizer/Problem/CLIArgumentProblem.hpp
+++ b/include/firestarter/Optimizer/Problem/CLIArgumentProblem.hpp
@@ -26,6 +26,7 @@
 #include "firestarter/Optimizer/Problem.hpp"
 
 #include <cassert>
+#include <cmath>
 #include <functional>
 #include <stdexcept>
 #include <thread>

--- a/include/firestarter/Optimizer/Problem/CLIArgumentProblem.hpp
+++ b/include/firestarter/Optimizer/Problem/CLIArgumentProblem.hpp
@@ -45,7 +45,7 @@ private:
   std::shared_ptr<firestarter::measurement::MeasurementWorker> MeasurementWorker;
   /// The metrics that are used in the optimization. They may have a dash at the start to allow them to be changed from
   /// maximization to minimization.
-  std::vector<MetricName> Metrics;
+  std::vector<MetricName> OptimizationMetrics;
   /// The duration of the measurement.
   std::chrono::seconds Timeout;
   /// The time to skip from the measurement start
@@ -74,7 +74,7 @@ public:
                      std::vector<std::string> Instructions)
       : ChangePayloadFunction(std::move(ChangePayloadFunction))
       , MeasurementWorker(std::move(MeasurementWorker))
-      , Metrics(Metrics)
+      , OptimizationMetrics(Metrics)
       , Timeout(Timeout)
       , StartDelta(StartDelta)
       , StopDelta(StopDelta)
@@ -121,7 +121,7 @@ public:
   [[nodiscard]] auto fitness(measurement::MetricSummaries const& Summaries) const -> std::vector<double> override {
     std::vector<double> Values = {};
 
-    for (auto const& MetricName : Metrics) {
+    for (auto const& MetricName : OptimizationMetrics) {
       auto It = std::find_if(Summaries.cbegin(), Summaries.cend(), [&MetricName](const auto& NameValuePair) {
         return NameValuePair.first.isSameMetric(MetricName);
       });
@@ -155,7 +155,7 @@ public:
   }
 
   /// Get the number of optimization objectives.
-  [[nodiscard]] auto getNobjs() const -> std::size_t override { return Metrics.size(); }
+  [[nodiscard]] auto getNobjs() const -> std::size_t override { return OptimizationMetrics.size(); }
 };
 
 } // namespace firestarter::optimizer::problem

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,9 @@ add_library(firestartercore STATIC
 	firestarter/Config/CpuBind.cpp
 	firestarter/Config/InstructionGroups.cpp
 	firestarter/Config/MetricName.cpp
+	
+	firestarter/Measurement/Metric.cpp
+	firestarter/Measurement/Summary.cpp
 
 	firestarter/Payload/CompiledPayload.cpp
 	firestarter/Payload/PayloadSettings.cpp
@@ -45,7 +48,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 	add_library(firestarterlinux STATIC
 		# measurement stuff
 		firestarter/Measurement/MeasurementWorker.cpp
-		firestarter/Measurement/Summary.cpp
 		firestarter/Measurement/Metric/IPCEstimate.cpp
 		firestarter/Measurement/Metric/RAPL.cpp
 		firestarter/Measurement/Metric/Perf.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,8 +10,9 @@ add_library(firestartercore STATIC
 	firestarter/ProcessorInformation.cpp
 
 	firestarter/Config/Config.cpp
-	firestarter/Config/InstructionGroups.cpp
 	firestarter/Config/CpuBind.cpp
+	firestarter/Config/InstructionGroups.cpp
+	firestarter/Config/MetricName.cpp
 
 	firestarter/Payload/CompiledPayload.cpp
 	firestarter/Payload/PayloadSettings.cpp

--- a/src/firestarter/Config/Config.cpp
+++ b/src/firestarter/Config/Config.cpp
@@ -22,6 +22,7 @@
 #include "firestarter/Config/Config.hpp"
 #include "firestarter/Config/CpuBind.hpp"
 #include "firestarter/Config/InstructionGroups.hpp"
+#include "firestarter/Config/MetricName.hpp"
 #include "firestarter/Constants.hpp"
 #include "firestarter/Logging/Log.hpp"
 #include "firestarter/SafeExit.hpp"

--- a/src/firestarter/Config/Config.cpp
+++ b/src/firestarter/Config/Config.cpp
@@ -30,6 +30,7 @@
 #include <cstdlib>
 #include <cxxopts.hpp>
 #include <exception>
+#include <iterator>
 #include <nitro/log/severity.hpp>
 #include <stdexcept>
 #include <string>
@@ -372,7 +373,9 @@ Config::Config(int Argc, const char** Argv)
         Preheat = std::chrono::seconds(Options["preheat"].as<unsigned>());
         OptimizationAlgorithm = Options["optimize"].as<std::string>();
         if (static_cast<bool>(Options.count("optimization-metric"))) {
-          OptimizationMetrics = Options["optimization-metric"].as<std::vector<std::string>>();
+          const auto Metrics = Options["optimization-metric"].as<std::vector<std::string>>();
+          std::transform(Metrics.cbegin(), Metrics.cend(), std::back_inserter(OptimizationMetrics),
+                         [](const std::string& Metric) { return MetricName::fromString(Metric); });
         }
         if (LoadPercent != 100) {
           throw std::invalid_argument("Options -p | --period and -l | --load are "

--- a/src/firestarter/Config/Config.cpp
+++ b/src/firestarter/Config/Config.cpp
@@ -33,6 +33,7 @@
 #include <exception>
 #include <iterator>
 #include <nitro/log/severity.hpp>
+#include <set>
 #include <stdexcept>
 #include <string>
 #include <utility>

--- a/src/firestarter/Config/Config.cpp
+++ b/src/firestarter/Config/Config.cpp
@@ -354,10 +354,14 @@ Config::Config(int Argc, const char** Argv)
       StopDelta = std::chrono::milliseconds(Options["stop-delta"].as<unsigned>());
       MeasurementInterval = std::chrono::milliseconds(Options["measurement-interval"].as<unsigned>());
 #ifndef FIRESTARTER_LINK_STATIC
-      MetricPaths = Options["metric-path"].as<std::vector<std::string>>();
+      {
+        const auto Metrics = Options["metric-path"].as<std::vector<std::string>>();
+        MetricPaths = std::set<std::string>(Metrics.cbegin(), Metrics.cend());
+      }
 #endif
       if (static_cast<bool>(Options.count("metric-from-stdin"))) {
-        StdinMetrics = Options["metric-from-stdin"].as<std::vector<std::string>>();
+        const auto Metrics = Options["metric-from-stdin"].as<std::vector<std::string>>();
+        StdinMetrics = std::set<std::string>(Metrics.cbegin(), Metrics.cend());
       }
       Measurement = static_cast<bool>(Options.count("measurement"));
       ListMetrics = static_cast<bool>(Options.count("list-metrics"));
@@ -375,7 +379,9 @@ Config::Config(int Argc, const char** Argv)
         OptimizationAlgorithm = Options["optimize"].as<std::string>();
         if (static_cast<bool>(Options.count("optimization-metric"))) {
           const auto Metrics = Options["optimization-metric"].as<std::vector<std::string>>();
-          std::transform(Metrics.cbegin(), Metrics.cend(), std::back_inserter(OptimizationMetrics),
+
+          std::transform(Metrics.cbegin(), Metrics.cend(),
+                         std::inserter(OptimizationMetrics, OptimizationMetrics.begin()),
                          [](const std::string& Metric) { return MetricName::fromString(Metric); });
         }
         if (LoadPercent != 100) {

--- a/src/firestarter/Config/MetricName.cpp
+++ b/src/firestarter/Config/MetricName.cpp
@@ -21,7 +21,10 @@
 
 #include "firestarter/Config/MetricName.hpp"
 
+#include <optional>
 #include <regex>
+#include <stdexcept>
+#include <string>
 
 namespace firestarter {
 
@@ -31,7 +34,7 @@ auto MetricName::fromString(const std::string& Metric) -> MetricName {
   std::smatch M;
 
   if (std::regex_match(Metric, M, Re)) {
-    bool Inverted = M[1].length() == 1;
+    const bool Inverted = M[1].length() == 1;
     auto RootMetricName = M[2].str();
     std::optional<std::string> SubmetricName;
     if (M[4].matched) {

--- a/src/firestarter/Config/MetricName.cpp
+++ b/src/firestarter/Config/MetricName.cpp
@@ -20,7 +20,6 @@
  *****************************************************************************/
 
 #include "firestarter/Config/MetricName.hpp"
-#include "firestarter/Logging/Log.hpp"
 
 #include <regex>
 

--- a/src/firestarter/Config/MetricName.cpp
+++ b/src/firestarter/Config/MetricName.cpp
@@ -20,17 +20,18 @@
  *****************************************************************************/
 
 #include "firestarter/Config/MetricName.hpp"
+#include "firestarter/Logging/Log.hpp"
 
 #include <regex>
 
 namespace firestarter {
 
 auto MetricName::fromString(const std::string& Metric) -> MetricName {
-  const std::regex Re("^(-)(\\w+)(/\\w+)$");
+  const std::regex Re("(^(-)?([\\w-]+)(/[\\w-]+)?$)");
   std::smatch M;
 
   if (std::regex_match(Metric, M, Re)) {
-    bool Inverted = M[0].matched;
+    bool Inverted = M[0].length() == 1;
     auto RootMetricName = M[1].str();
     std::optional<std::string> SubmetricName;
     if (M[2].matched) {
@@ -39,7 +40,7 @@ auto MetricName::fromString(const std::string& Metric) -> MetricName {
     return {Inverted, RootMetricName, SubmetricName};
   }
 
-  throw std::invalid_argument("Could not parse the metric name");
+  throw std::invalid_argument("Could not parse the metric name: " + Metric);
 }
 
 } // namespace firestarter

--- a/src/firestarter/Config/MetricName.cpp
+++ b/src/firestarter/Config/MetricName.cpp
@@ -1,0 +1,45 @@
+/******************************************************************************
+ * FIRESTARTER - A Processor Stress Test Utility
+ * Copyright (C) 2025 TU Dresden, Center for Information Services and High
+ * Performance Computing
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/\>.
+ *
+ * Contact: daniel.hackenberg@tu-dresden.de
+ *****************************************************************************/
+
+#include "firestarter/Config/MetricName.hpp"
+
+#include <regex>
+
+namespace firestarter {
+
+auto MetricName::fromString(const std::string& Metric) -> MetricName {
+  const std::regex Re("^(-)(\\w+)(/\\w+)$");
+  std::smatch M;
+
+  if (std::regex_match(Metric, M, Re)) {
+    bool Inverted = M[0].matched;
+    auto RootMetricName = M[1].str();
+    std::optional<std::string> SubmetricName;
+    if (M[2].matched) {
+      SubmetricName = M[2].str();
+    }
+    return {Inverted, RootMetricName, SubmetricName};
+  }
+
+  throw std::invalid_argument("Could not parse the metric name");
+}
+
+} // namespace firestarter

--- a/src/firestarter/Firestarter.cpp
+++ b/src/firestarter/Firestarter.cpp
@@ -153,7 +153,7 @@ Firestarter::Firestarter(Config&& ProvidedConfig)
 
         for (auto const& Thread : LoadThreads) {
           auto Td = Thread.second;
-          IpcEstimateMetricData::insertValue(
+          IpcEstimateMetric::insertValue(
               static_cast<double>(Td->LastRun.Iterations) *
               static_cast<double>(LoadThreads.front().second->CompiledPayloadPtr->stats().Instructions) /
               static_cast<double>(StopTimestamp - StartTimestamp));

--- a/src/firestarter/Firestarter.cpp
+++ b/src/firestarter/Firestarter.cpp
@@ -115,8 +115,8 @@ Firestarter::Firestarter(Config&& ProvidedConfig)
       }
 
       // init all metrics
-      auto All = MeasurementWorker->metricNames();
-      auto Initialized = MeasurementWorker->initMetrics(All);
+      const auto All = MeasurementWorker->metricNames();
+      const auto Initialized = MeasurementWorker->initMetrics(All);
 
       if (Initialized.empty()) {
         std::invalid_argument("No metrics initialized");
@@ -128,10 +128,6 @@ Firestarter::Firestarter(Config&& ProvidedConfig)
           auto InvertedName = "-" + Name;
           return Name == OptimizationMetric || InvertedName == OptimizationMetric;
         };
-        // metric name is not found
-        if (std::find_if(All.begin(), All.end(), NameEqual) == All.end()) {
-          std::invalid_argument("Metric \"" + OptimizationMetric + "\" does not exist.");
-        }
         // metric has not initialized properly
         if (std::find_if(Initialized.begin(), Initialized.end(), NameEqual) == Initialized.end()) {
           std::invalid_argument("Metric \"" + OptimizationMetric + "\" failed to initialize.");

--- a/src/firestarter/Firestarter.cpp
+++ b/src/firestarter/Firestarter.cpp
@@ -125,7 +125,7 @@ Firestarter::Firestarter(Config&& ProvidedConfig)
         auto NameEqual = [&OptimizationMetric](auto const& Name) { return Name.isSameMetric(OptimizationMetric); };
         // metric has not initialized properly
         if (std::find_if(Initialized.cbegin(), Initialized.cend(), NameEqual) == Initialized.cend()) {
-          std::invalid_argument("Metric \"" + OptimizationMetric.toString() + "\" failed to initialize.");
+          throw std::invalid_argument("Metric \"" + OptimizationMetric.toString() + "\" failed to initialize.");
         }
       }
     }

--- a/src/firestarter/Firestarter.cpp
+++ b/src/firestarter/Firestarter.cpp
@@ -122,9 +122,7 @@ Firestarter::Firestarter(Config&& ProvidedConfig)
 
       // check if selected metrics are initialized
       for (auto const& OptimizationMetric : Cfg.OptimizationMetrics) {
-        auto NameEqual = [&OptimizationMetric](auto const& Name) { return Name.isSameMetric(OptimizationMetric); };
-        // metric has not initialized properly
-        if (std::find_if(Initialized.cbegin(), Initialized.cend(), NameEqual) == Initialized.cend()) {
+        if (!static_cast<bool>(Initialized.count(OptimizationMetric))) {
           throw std::invalid_argument("Metric \"" + OptimizationMetric.toString() + "\" failed to initialize.");
         }
       }

--- a/src/firestarter/LoadWorker.cpp
+++ b/src/firestarter/LoadWorker.cpp
@@ -223,7 +223,7 @@ void Firestarter::printPerformanceReport() {
   if (Cfg.Measurement) {
     for (auto const& Thread : LoadThreads) {
       auto Td = Thread.second;
-      IpcEstimateMetricData::insertValue(
+      IpcEstimateMetric::insertValue(
           static_cast<double>(Td->LastRun.Iterations) *
           static_cast<double>(LoadThreads.front().second->CompiledPayloadPtr->stats().Instructions) /
           static_cast<double>(StopTimestamp - StartTimestamp));

--- a/src/firestarter/Measurement/MeasurementWorker.cpp
+++ b/src/firestarter/Measurement/MeasurementWorker.cpp
@@ -89,7 +89,7 @@ MeasurementWorker::~MeasurementWorker() {
   if (WorkerThread.joinable()) {
     WorkerThread.join();
   }
-  if (WorkerThread.joinable()) {
+  if (StdinThread.joinable()) {
     StdinThread.detach();
   }
 }

--- a/src/firestarter/Measurement/MeasurementWorker.cpp
+++ b/src/firestarter/Measurement/MeasurementWorker.cpp
@@ -237,7 +237,7 @@ void MeasurementWorker::stdinDataAcquisitionWorker(MeasurementWorker& This) {
 
     auto* Metric = This.findRootMetricByName(Name.data());
     if (Metric) {
-      Metric->insert(Time, Value);
+      Metric->insert(ROOT_METRIC_INDEX, Time, Value);
     }
   }
 }

--- a/src/firestarter/Measurement/MeasurementWorker.cpp
+++ b/src/firestarter/Measurement/MeasurementWorker.cpp
@@ -21,7 +21,10 @@
 
 #include "firestarter/Measurement/MeasurementWorker.hpp"
 #include "firestarter/Config/MetricName.hpp"
+#include "firestarter/Measurement/Metric.hpp"
+#include "firestarter/Measurement/MetricInterface.h"
 
+#include <algorithm>
 #include <array>
 #include <chrono>
 #include <cmath>
@@ -30,6 +33,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <functional>
 #include <queue>
 #include <set>
 #include <stdexcept>
@@ -37,12 +41,6 @@
 #include <thread>
 #include <tuple>
 #include <vector>
-
-#if defined(linux) || defined(__linux__)
-extern "C" {
-#include <pthread.h>
-}
-#endif
 
 namespace {
 
@@ -65,7 +63,7 @@ MeasurementWorker::MeasurementWorker(std::chrono::milliseconds UpdateInterval, u
                                      std::vector<std::string> const& StdinMetricsNames)
     : UpdateInterval(UpdateInterval)
     , NumThreads(NumThreads) {
-#ifndef FIRESTARTER_LINK_STATIC
+#if not(defined(FIRESTARTER_LINK_STATIC)) && defined(linux)
   for (auto const& Dylib : MetricDylibsNames) {
     Metrics.emplace_back(RootMetric::fromDylib(Dylib));
   }

--- a/src/firestarter/Measurement/Metric.cpp
+++ b/src/firestarter/Measurement/Metric.cpp
@@ -82,7 +82,7 @@ auto RootMetric::fromDylib(const std::string& DylibPath) -> std::shared_ptr<Root
   Handle = dlopen(Filename, RTLD_NOW | RTLD_LOCAL);
 
   if (!Handle) {
-    firestarter::log::error() << Filename << ": " << dlerror();
+    log::error() << Filename << ": " << dlerror();
     return nullptr;
   }
 
@@ -95,7 +95,7 @@ auto RootMetric::fromDylib(const std::string& DylibPath) -> std::shared_ptr<Root
 
   char* Error = nullptr;
   if ((Error = dlerror()) != nullptr) {
-    firestarter::log::error() << Filename << ": " << Error;
+    log::error() << Filename << ": " << Error;
     dlclose(Handle);
     return nullptr;
   }

--- a/src/firestarter/Measurement/Metric.cpp
+++ b/src/firestarter/Measurement/Metric.cpp
@@ -19,8 +19,6 @@
  * Contact: daniel.hackenberg@tu-dresden.de
  *****************************************************************************/
 
-#pragma once
-
 #include "firestarter/Measurement/Metric.hpp"
 #include "firestarter/Config/MetricName.hpp"
 #include "firestarter/Logging/Log.hpp"

--- a/src/firestarter/Measurement/Metric.cpp
+++ b/src/firestarter/Measurement/Metric.cpp
@@ -1,0 +1,284 @@
+/******************************************************************************
+ * FIRESTARTER - A Processor Stress Test Utility
+ * Copyright (C) 2025 TU Dresden, Center for Information Services and High
+ * Performance Computing
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/\>.
+ *
+ * Contact: daniel.hackenberg@tu-dresden.de
+ *****************************************************************************/
+
+#pragma once
+
+#include "firestarter/Measurement/Metric.hpp"
+#include "firestarter/Logging/Log.hpp"
+#include <cmath>
+
+#if not(defined(FIRESTARTER_LINK_STATIC)) && defined(linux)
+extern "C" {
+#include <dlfcn.h>
+}
+#endif
+
+namespace {}; // namespace
+
+namespace firestarter::measurement {
+
+auto LeafMetric::metricName() -> MetricName { return {/*Inverted=*/false, RootRef.Name, Name}; }
+
+RootMetric::~RootMetric() {
+  if (Initialized && MetricPtr) {
+    MetricPtr->Fini();
+  }
+
+#if not(defined(FIRESTARTER_LINK_STATIC)) && defined(linux)
+  if (Dylib) {
+    dlclose(MetricPtr);
+  }
+#endif
+  Initialized = false;
+}
+
+auto RootMetric::fromCInterface(MetricInterface& Metric) -> std::shared_ptr<RootMetric> {
+  auto Root = std::make_shared<RootMetric>(/*Name=*/Metric.Name,
+                                           /*Dylib=*/false,
+                                           /*Stdin=*/false,
+                                           /*Initialized=*/false);
+  Root->MetricPtr = &Metric;
+  Root->checkAvailability();
+  return Root;
+}
+
+#if not(defined(FIRESTARTER_LINK_STATIC)) && defined(linux)
+auto RootMetric::fromDylib(const std::string& DylibPath) -> std::shared_ptr<RootMetric> {
+  void* Handle = nullptr;
+  const char* Filename = DylibPath.c_str();
+
+  Handle = dlopen(Filename, RTLD_NOW | RTLD_LOCAL);
+
+  if (!Handle) {
+    firestarter::log::error() << Filename << ": " << dlerror();
+    return nullptr;
+  }
+
+  // clear existing error
+  dlerror();
+
+  MetricInterface* Metric = nullptr;
+
+  Metric = static_cast<MetricInterface*>(dlsym(Handle, "metric"));
+
+  char* Error = nullptr;
+  if ((Error = dlerror()) != nullptr) {
+    firestarter::log::error() << Filename << ": " << Error;
+    dlclose(Handle);
+    return nullptr;
+  }
+
+  auto Root = std::make_shared<RootMetric>(/*Name=*/Metric->Name,
+                                           /*Dylib=*/true,
+                                           /*Stdin=*/false,
+                                           /*Initialized=*/false);
+  Root->checkAvailability();
+  return Root;
+}
+#endif
+
+auto RootMetric::fromStdin(const std::string& MetricName) -> std::shared_ptr<RootMetric> {
+  auto Root = std::make_shared<RootMetric>(/*Name=*/MetricName,
+                                           /*Dylib=*/false,
+                                           /*Stdin=*/true,
+                                           /*Initialized=*/true);
+
+  Root->checkAvailability();
+  return Root;
+}
+
+auto RootMetric::initialize() -> bool {
+  // Skip if already initialized
+  if (Initialized) {
+    return true;
+  }
+
+  log::debug() << "Initializing metric " << Name;
+
+  // Clear the contained data
+  {
+    std::lock_guard<std::mutex> Lock(ValuesMutex);
+    Values.clear();
+  }
+  // Init the associated metric interface object
+  if (MetricPtr) {
+    const auto ReturnValue = MetricPtr->Init();
+
+    Initialized = ReturnValue == EXIT_SUCCESS;
+    if (!Initialized) {
+      log::warn() << "Metric " << Name << ": " << MetricPtr->GetError();
+      return false;
+    }
+
+    // Register the callback to insert data
+    if (MetricPtr->Type.InsertCallback) {
+      MetricPtr->RegisterInsertCallback(insertCallback, this);
+    }
+  }
+
+  return true;
+}
+
+auto RootMetric::getTimedCallback() -> std::optional<std::tuple<std::function<void()>, std::chrono::microseconds>> {
+  if (!MetricPtr) {
+    return {};
+  }
+
+  auto CallbackTime = std::chrono::microseconds(MetricPtr->CallbackTime);
+  if (CallbackTime.count() == 0) {
+    return {};
+  }
+
+  auto Callback = [this]() {
+    if (Initialized) {
+      MetricPtr->Callback();
+    }
+  };
+
+  return std::tuple<std::function<void()>, std::chrono::microseconds>{Callback, CallbackTime};
+}
+
+auto RootMetric::getInsertCallback() -> std::optional<std::function<void()>> {
+  if (!MetricPtr) {
+    return {};
+  }
+
+  auto Callback = [this]() {
+    std::vector<double> Values(1 + Submetrics.size(), NAN);
+
+    if (Initialized && EXIT_SUCCESS == MetricPtr->GetReading(Values.data(), Values.size())) {
+      for (auto I = 0U; I < Values.size(); I++) {
+        insert(/*MetricIndex=*/I, std::chrono::high_resolution_clock::now(), Values[I]);
+      }
+    }
+  };
+
+  if (!MetricPtr->Type.InsertCallback && MetricPtr->GetReading != nullptr) {
+    return Callback;
+  }
+
+  return {};
+}
+
+auto RootMetric::metricName() -> MetricName { return {/*Inverted=*/false, Name}; }
+
+auto RootMetric::getMetricNames() -> std::vector<MetricName> {
+  std::vector<MetricName> MetricNames;
+  MetricNames.emplace_back(metricName());
+
+  std::transform(Submetrics.cbegin(), Submetrics.cend(), std::back_inserter(MetricNames),
+                 [](const auto& SubMetric) { return SubMetric->metricName(); });
+
+  return MetricNames;
+}
+
+void RootMetric::insert(uint64_t MetricIndex, std::chrono::high_resolution_clock::time_point Time, double Value) {
+  const std::lock_guard<std::mutex> Lock(ValuesMutex);
+
+  if (MetricIndex == ROOT_METRIC_INDEX) {
+    Values.emplace_back(Time, Value);
+  } else {
+    auto Index = MetricIndex - 1;
+    if (Index < Submetrics.size()) {
+      Submetrics[Index]->Values.emplace_back(Time, Value);
+    }
+  }
+}
+
+void RootMetric::insert(uint64_t MetricIndex, int64_t TimeSinceEpoch, double Value) {
+  using Duration = std::chrono::duration<int64_t, std::nano>;
+  auto Time = std::chrono::time_point<std::chrono::high_resolution_clock, Duration>(Duration(TimeSinceEpoch));
+
+  insert(MetricIndex, Time, Value);
+}
+
+auto RootMetric::getSummaries(std::chrono::high_resolution_clock::time_point StartTime,
+                              std::chrono::high_resolution_clock::time_point StopTime,
+                              std::chrono::milliseconds StartDelta, std::chrono::milliseconds StopDelta,
+                              const uint64_t NumThreads) -> MetricSummaries {
+  MetricType Type{};
+
+  if (MetricPtr == nullptr) {
+    Type.Absolute = 1;
+
+    StartTime += StartDelta;
+    StopTime -= StopDelta;
+  } else {
+    Type = MetricPtr->Type;
+
+    if (!Type.IgnoreStartStopDelta) {
+      StartTime += StartDelta;
+      StopTime -= StopDelta;
+    }
+  }
+
+  MetricSummaries Summaries;
+
+  auto FindAll = [&StartTime, &StopTime](auto const& Tv) { return StartTime <= Tv.Time && Tv.Time <= StopTime; };
+
+  {
+    decltype(Values) CroppedValues;
+
+    {
+      std::lock_guard<std::mutex> Lock(ValuesMutex);
+      std::copy_if(Values.cbegin(), Values.cend(), std::back_inserter(CroppedValues), FindAll);
+    }
+
+    Summaries[metricName()] = Summary::calculate(CroppedValues.begin(), CroppedValues.end(), Type, NumThreads);
+  }
+
+  for (const auto& Submetric : Submetrics) {
+    decltype(Submetric->Values) CroppedValues;
+
+    {
+      std::lock_guard<std::mutex> Lock(Submetric->ValuesMutex);
+      std::copy_if(Submetric->Values.cbegin(), Submetric->Values.cend(), std::back_inserter(CroppedValues), FindAll);
+    }
+
+    Summaries[Submetric->metricName()] =
+        Summary::calculate(CroppedValues.begin(), CroppedValues.end(), Type, NumThreads);
+  }
+
+  return Summaries;
+}
+
+void RootMetric::checkAvailability() {
+  if (MetricPtr) {
+    auto ReturnCode = MetricPtr->Init();
+    Available = ReturnCode == EXIT_SUCCESS;
+
+    // Get the submetrics
+    if (Available && MetricPtr->GetSubmetricNames) {
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+      for (auto** Names = MetricPtr->GetSubmetricNames(); *Names; Names++) {
+        // Create a new submetric entry for each name
+        Submetrics.emplace_back(std::make_unique<LeafMetric>(std::string(*Names), *this));
+      }
+    }
+
+    MetricPtr->Fini();
+
+  } else {
+    Available = true;
+  }
+}
+
+} // namespace firestarter::measurement

--- a/src/firestarter/Measurement/Metric.cpp
+++ b/src/firestarter/Measurement/Metric.cpp
@@ -22,8 +22,26 @@
 #pragma once
 
 #include "firestarter/Measurement/Metric.hpp"
+#include "firestarter/Config/MetricName.hpp"
 #include "firestarter/Logging/Log.hpp"
+#include "firestarter/Measurement/MetricInterface.h"
+#include "firestarter/Measurement/Summary.hpp"
+
+#include <algorithm>
+#include <chrono>
 #include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <functional>
+#include <iterator>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <ratio>
+#include <string>
+#include <tuple>
+#include <vector>
 
 #if not(defined(FIRESTARTER_LINK_STATIC)) && defined(linux)
 extern "C" {
@@ -42,7 +60,7 @@ auto Metric::getSummary(const std::chrono::high_resolution_clock::time_point Sta
   decltype(Values) CroppedValues;
 
   {
-    std::lock_guard<std::mutex> Lock(ValuesMutex);
+    const std::lock_guard<std::mutex> Lock(ValuesMutex);
     std::copy_if(Values.cbegin(), Values.cend(), std::back_inserter(CroppedValues), FindAll);
   }
 
@@ -129,7 +147,7 @@ auto RootMetric::initialize() -> bool {
 
   // Clear the contained data
   {
-    std::lock_guard<std::mutex> Lock(ValuesMutex);
+    const std::lock_guard<std::mutex> Lock(ValuesMutex);
     Values.clear();
   }
   // Init the associated metric interface object

--- a/src/firestarter/Measurement/Metric/IPCEstimate.cpp
+++ b/src/firestarter/Measurement/Metric/IPCEstimate.cpp
@@ -20,6 +20,7 @@
  *****************************************************************************/
 
 #include "firestarter/Measurement/Metric/IPCEstimate.hpp"
+#include "firestarter/Measurement/MetricInterface.h"
 
 #include <chrono>
 #include <cstdint>

--- a/src/firestarter/Measurement/Metric/IPCEstimate.cpp
+++ b/src/firestarter/Measurement/Metric/IPCEstimate.cpp
@@ -26,7 +26,7 @@
 #include <cstdint>
 #include <cstdlib>
 
-auto IpcEstimateMetricData::fini() -> int32_t {
+auto IpcEstimateMetric::fini() -> int32_t {
   auto& Instance = instance();
 
   Instance.Callback = nullptr;
@@ -35,18 +35,18 @@ auto IpcEstimateMetricData::fini() -> int32_t {
   return EXIT_SUCCESS;
 }
 
-auto IpcEstimateMetricData::init() -> int32_t {
+auto IpcEstimateMetric::init() -> int32_t {
   instance().ErrorString = "";
 
   return EXIT_SUCCESS;
 }
 
-auto IpcEstimateMetricData::getError() -> const char* {
+auto IpcEstimateMetric::getError() -> const char* {
   const char* ErrorCString = instance().ErrorString.c_str();
   return ErrorCString;
 }
 
-auto IpcEstimateMetricData::registerInsertCallback(void (*C)(void*, uint64_t, int64_t, double), void* Arg) -> int32_t {
+auto IpcEstimateMetric::registerInsertCallback(void (*C)(void*, uint64_t, int64_t, double), void* Arg) -> int32_t {
   auto& Instance = instance();
 
   Instance.Callback = C;
@@ -55,7 +55,7 @@ auto IpcEstimateMetricData::registerInsertCallback(void (*C)(void*, uint64_t, in
   return EXIT_SUCCESS;
 }
 
-void IpcEstimateMetricData::insertValue(double Value) {
+void IpcEstimateMetric::insertValue(double Value) {
   auto& Instance = instance();
 
   if (Instance.Callback == nullptr || Instance.CallbackArg == nullptr) {

--- a/src/firestarter/Measurement/Metric/IPCEstimate.cpp
+++ b/src/firestarter/Measurement/Metric/IPCEstimate.cpp
@@ -45,8 +45,7 @@ auto IpcEstimateMetricData::getError() -> const char* {
   return ErrorCString;
 }
 
-auto IpcEstimateMetricData::registerInsertCallback(void (*C)(void*, const char*, int64_t, double),
-                                                   void* Arg) -> int32_t {
+auto IpcEstimateMetricData::registerInsertCallback(void (*C)(void*, uint64_t, int64_t, double), void* Arg) -> int32_t {
   auto& Instance = instance();
 
   Instance.Callback = C;
@@ -66,5 +65,5 @@ void IpcEstimateMetricData::insertValue(double Value) {
       std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now().time_since_epoch())
           .count();
 
-  Instance.Callback(Instance.CallbackArg, "ipc-estimate", T, Value);
+  Instance.Callback(Instance.CallbackArg, ROOT_METRIC_INDEX, T, Value);
 }

--- a/src/firestarter/Measurement/Metric/Perf.cpp
+++ b/src/firestarter/Measurement/Metric/Perf.cpp
@@ -221,9 +221,15 @@ auto PerfMetricData::getReading(double* IpcValue, double* FreqValue) -> int32_t 
   return EXIT_SUCCESS;
 }
 
-auto PerfMetricData::getReadingIpc(double* Value) -> int32_t { return getReading(Value, nullptr); }
+auto PerfMetricData::getReadingIpc(double* Value, uint64_t NumElems) -> int32_t {
+  assert(NumElems == 1 && "The number of elements should be exctly one, since no submetrics are available.");
+  return getReading(Value, nullptr);
+}
 
-auto PerfMetricData::getReadingFreq(double* Value) -> int32_t { return getReading(nullptr, Value); }
+auto PerfMetricData::getReadingFreq(double* Value, uint64_t NumElems) -> int32_t {
+  assert(NumElems == 1 && "The number of elements should be exctly one, since no submetrics are available.");
+  return getReading(nullptr, Value);
+}
 
 auto PerfMetricData::getError() -> const char* {
   const char* ErrorCString = instance().ErrorString.c_str();

--- a/src/firestarter/Measurement/Metric/Perf.cpp
+++ b/src/firestarter/Measurement/Metric/Perf.cpp
@@ -40,7 +40,7 @@ auto perfEventOpen(struct perf_event_attr* HwEvent, pid_t Pid, int Cpu, int Grou
 }
 } // namespace
 
-auto PerfMetricData::fini() -> int32_t {
+auto PerfMetric::fini() -> int32_t {
   auto& Instance = instance();
 
   if (!(Instance.CpuCyclesFd < 0)) {
@@ -55,7 +55,7 @@ auto PerfMetricData::fini() -> int32_t {
   return EXIT_SUCCESS;
 }
 
-auto PerfMetricData::init() -> int32_t {
+auto PerfMetric::init() -> int32_t {
   auto& Instance = instance();
 
   if (Instance.InitDone) {
@@ -175,7 +175,7 @@ auto PerfMetricData::init() -> int32_t {
   return EXIT_SUCCESS;
 }
 
-auto PerfMetricData::valueFromId(struct ReadFormat* Reader, uint64_t Id) -> uint64_t {
+auto PerfMetric::valueFromId(struct ReadFormat* Reader, uint64_t Id) -> uint64_t {
   for (decltype(Reader->Nr) I = 0; I < Reader->Nr; ++I) {
     assert(I < 2 && "Index is out of bounds");
     // NOLINTBEGIN(cppcoreguidelines-pro-bounds-constant-array-index)
@@ -188,7 +188,7 @@ auto PerfMetricData::valueFromId(struct ReadFormat* Reader, uint64_t Id) -> uint
   return 0;
 }
 
-auto PerfMetricData::getReading(double* IpcValue, double* FreqValue) -> int32_t {
+auto PerfMetric::getReading(double* IpcValue, double* FreqValue) -> int32_t {
   auto& Instance = instance();
 
   if (Instance.CpuCyclesFd < 0 || Instance.InstructionsFd < 0) {
@@ -221,17 +221,17 @@ auto PerfMetricData::getReading(double* IpcValue, double* FreqValue) -> int32_t 
   return EXIT_SUCCESS;
 }
 
-auto PerfMetricData::getReadingIpc(double* Value, uint64_t NumElems) -> int32_t {
+auto PerfMetric::getReadingIpc(double* Value, uint64_t NumElems) -> int32_t {
   assert(NumElems == 1 && "The number of elements should be exctly one, since no submetrics are available.");
   return getReading(Value, nullptr);
 }
 
-auto PerfMetricData::getReadingFreq(double* Value, uint64_t NumElems) -> int32_t {
+auto PerfMetric::getReadingFreq(double* Value, uint64_t NumElems) -> int32_t {
   assert(NumElems == 1 && "The number of elements should be exctly one, since no submetrics are available.");
   return getReading(nullptr, Value);
 }
 
-auto PerfMetricData::getError() -> const char* {
+auto PerfMetric::getError() -> const char* {
   const char* ErrorCString = instance().ErrorString.c_str();
   return ErrorCString;
 }

--- a/src/firestarter/Measurement/Metric/RAPL.cpp
+++ b/src/firestarter/Measurement/Metric/RAPL.cpp
@@ -28,6 +28,7 @@
 #include <cstring>
 #include <memory>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -53,9 +54,6 @@ auto RaplMetricData::init() -> int32_t {
     Instance.ErrorString = "Could not open " + std::string(RaplPath);
     return EXIT_FAILURE;
   }
-
-  // a vector of all paths to package and dram
-  std::vector<std::string> Paths = {};
 
   struct dirent* Dir = nullptr;
 

--- a/src/firestarter/Measurement/Metric/RAPL.cpp
+++ b/src/firestarter/Measurement/Metric/RAPL.cpp
@@ -140,11 +140,12 @@ auto RaplMetricData::getReading(double* Value, uint64_t NumElems) -> int32_t {
       FinalReading += Reader->lastReading();
     }
 
-    *Value = FinalReading;
-    for (auto I = 1U; I <= Readers.size(); I++) {
-      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-      Value[I] = Readers[I]->lastReading();
+    // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    *Value++ = FinalReading;
+    for (auto& Reader : Readers) {
+      *Value++ = Reader->lastReading();
     }
+    // NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic)
   }
 
   return EXIT_SUCCESS;

--- a/src/firestarter/Measurement/Metric/RAPL.cpp
+++ b/src/firestarter/Measurement/Metric/RAPL.cpp
@@ -36,7 +36,7 @@ extern "C" {
 #include <dirent.h>
 }
 
-auto RaplMetricData::fini() -> int32_t {
+auto RaplMetric::fini() -> int32_t {
   instance().Readers.clear();
   instance().AccumulateReaders.clear();
   instance().SubmetricNames = {nullptr};
@@ -44,7 +44,7 @@ auto RaplMetricData::fini() -> int32_t {
   return EXIT_SUCCESS;
 }
 
-auto RaplMetricData::init() -> int32_t {
+auto RaplMetric::init() -> int32_t {
   auto& Instance = instance();
 
   Instance.ErrorString = "";
@@ -119,7 +119,7 @@ auto RaplMetricData::init() -> int32_t {
   return EXIT_SUCCESS;
 }
 
-auto RaplMetricData::getReading(double* Value, uint64_t NumElems) -> int32_t {
+auto RaplMetric::getReading(double* Value, uint64_t NumElems) -> int32_t {
 
   // Update all readers
   auto& Readers = instance().Readers;
@@ -149,11 +149,11 @@ auto RaplMetricData::getReading(double* Value, uint64_t NumElems) -> int32_t {
   return EXIT_SUCCESS;
 }
 
-auto RaplMetricData::getError() -> const char* {
+auto RaplMetric::getError() -> const char* {
   const char* ErrorCString = instance().ErrorString.c_str();
   return ErrorCString;
 }
 
 // this function will be called periodically to make sure we do not miss an
 // overflow of the counter
-void RaplMetricData::callback() { getReading(nullptr, /*NumElems=*/0); }
+void RaplMetric::callback() { getReading(nullptr, /*NumElems=*/0); }

--- a/src/firestarter/Measurement/Metric/RAPL.cpp
+++ b/src/firestarter/Measurement/Metric/RAPL.cpp
@@ -21,7 +21,6 @@
 
 #include "firestarter/Measurement/Metric/RAPL.hpp"
 
-#include <cstddef>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
@@ -29,7 +28,6 @@
 #include <memory>
 #include <sstream>
 #include <string>
-#include <utility>
 #include <vector>
 
 extern "C" {

--- a/src/firestarter/Optimizer/Population.cpp
+++ b/src/firestarter/Optimizer/Population.cpp
@@ -21,13 +21,12 @@
 
 #include "firestarter/Optimizer/Population.hpp"
 #include "firestarter/Logging/Log.hpp"
-#include "firestarter/Measurement/Summary.hpp"
+#include "firestarter/Measurement/Metric.hpp"
 #include "firestarter/Optimizer/History.hpp"
 #include "firestarter/Optimizer/Individual.hpp"
 
 #include <cassert>
 #include <cstddef>
-#include <map>
 #include <random>
 #include <sstream>
 #include <string>
@@ -63,7 +62,7 @@ auto Population::size() const -> std::size_t { return X.size(); }
 void Population::append(Individual const& Ind) {
   assert(this->problem().getDims() == Ind.size());
 
-  std::map<std::string, firestarter::measurement::Summary> Metrics;
+  measurement::MetricSummaries Metrics;
 
   // check if we already evaluated this individual
   const auto OptionalMetric = History::find(Ind);

--- a/test/UnitTests/CMakeLists.txt
+++ b/test/UnitTests/CMakeLists.txt
@@ -2,6 +2,7 @@ add_executable(UnitTests
     CpuBindTest.cpp
     FunctionSelectionTest.cpp
     InstructionGroupsTest.cpp
+    MetricNameTest.cpp
     MetricsTest.cpp
     X86CpuFeaturesTest.cpp
     X86CpuModelTest.cpp

--- a/test/UnitTests/CMakeLists.txt
+++ b/test/UnitTests/CMakeLists.txt
@@ -2,6 +2,7 @@ add_executable(UnitTests
     CpuBindTest.cpp
     FunctionSelectionTest.cpp
     InstructionGroupsTest.cpp
+    MetricsTest.cpp
     X86CpuFeaturesTest.cpp
     X86CpuModelTest.cpp
     X86PayloadTest.cpp
@@ -11,6 +12,7 @@ add_executable(UnitTests
 target_link_libraries(UnitTests
     firestartercore
     GTest::gtest_main
+    GTest::gmock_main
 )
 
 include(GoogleTest)

--- a/test/UnitTests/MetricNameTest.cpp
+++ b/test/UnitTests/MetricNameTest.cpp
@@ -22,10 +22,12 @@
 #include "firestarter/Config/MetricName.hpp"
 
 #include <gtest/gtest.h>
+#include <optional>
+#include <string>
+#include <utility>
 
-TEST(MetricNameTest, ParseValidInput) {
-
-  const auto StringToParsed = std::map<std::string, firestarter::MetricName>({
+TEST(MetricNameTest, CheckFromToString) {
+  const auto StringToParsed = std::vector<std::pair<std::string, firestarter::MetricName>>({
       {"sysfs-powercap-rapl", firestarter::MetricName(/*Inverted*/ false, "sysfs-powercap-rapl")},
       {"-sysfs-powercap-rapl", firestarter::MetricName(/*Inverted*/ true, "sysfs-powercap-rapl")},
       {"sysfs-powercap-rapl/sub-metric1",
@@ -40,5 +42,22 @@ TEST(MetricNameTest, ParseValidInput) {
     EXPECT_EQ(Name, Output);
 
     EXPECT_EQ(Name.toString(), Input);
+  }
+}
+
+TEST(MetricNameTest, CheckToStringWithoutAttributes) {
+  const auto StringToParsed = std::vector<std::pair<firestarter::MetricName, std::string>>({
+      {firestarter::MetricName(/*Inverted*/ false, "sysfs-powercap-rapl"), "sysfs-powercap-rapl"},
+      {firestarter::MetricName(/*Inverted*/ true, "sysfs-powercap-rapl"), "sysfs-powercap-rapl"},
+      {firestarter::MetricName(/*Inverted*/ false, "sysfs-powercap-rapl", "sub-metric1"),
+       "sysfs-powercap-rapl/sub-metric1"},
+      {firestarter::MetricName(/*Inverted*/ true, "sysfs-powercap-rapl", "sub-metric2"),
+       "sysfs-powercap-rapl/sub-metric2"},
+  });
+
+  // Check if the individual ones work.
+  for (const auto& [Input, Output] : StringToParsed) {
+    const auto Name = Input.toStringWithoutAttributes();
+    EXPECT_EQ(Name, Output);
   }
 }

--- a/test/UnitTests/MetricsTest.cpp
+++ b/test/UnitTests/MetricsTest.cpp
@@ -21,11 +21,10 @@
 
 #include "firestarter/Measurement/Metric.hpp"
 #include "firestarter/Measurement/MetricInterface.h"
+#include "firestarter/Measurement/TimeValue.hpp"
 
-#include "gtest/gtest.h"
 #include <chrono>
 #include <cstdint>
-#include <firestarter/Measurement/TimeValue.hpp>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/test/UnitTests/MetricsTest.cpp
+++ b/test/UnitTests/MetricsTest.cpp
@@ -65,6 +65,8 @@ template <int32_t InitReturnValue, const MetricType& Type, uint64_t CallbackTime
       /*Callback=*/callback,
       /*Init=*/init<InitReturnValue>,
       /*Fini=*/fini,
+      /*GetSubmetricNames=*/
+      nullptr,
       /*GetReading=*/getReading,
       /*GetError=*/getError,
       /*RegisterInsertCallback=*/registerInsertCallback,

--- a/test/UnitTests/MetricsTest.cpp
+++ b/test/UnitTests/MetricsTest.cpp
@@ -428,22 +428,20 @@ TEST(MetricsTest, CheckSubmetricsFromCInterface) {
   EXPECT_EQ(AvailableRoot->Name, AvailableMetricMock.FakeName);
   EXPECT_TRUE(AvailableRoot->Values.empty());
   EXPECT_EQ(AvailableRoot->MetricPtr, &AvailableMetricMock.AvailableMetric);
-  EXPECT_TRUE(AvailableRoot->Submetrics.empty());
   EXPECT_FALSE(AvailableRoot->Dylib);
   EXPECT_FALSE(AvailableRoot->Stdin);
   EXPECT_FALSE(AvailableRoot->Initialized);
-
   EXPECT_TRUE(AvailableRoot->Available);
-
-  // Check if the metric inititializes
-  EXPECT_TRUE(AvailableRoot->initialize());
-
-  EXPECT_TRUE(AvailableRoot->Initialized);
 
   // Check that the submetrics are registered
   EXPECT_EQ(AvailableRoot->Submetrics.size(), 2);
   EXPECT_EQ(AvailableRoot->Submetrics[0]->Name, std::string(Submetrics[0]));
   EXPECT_EQ(AvailableRoot->Submetrics[1]->Name, std::string(Submetrics[1]));
+
+  // Check if the metric inititializes
+  EXPECT_TRUE(AvailableRoot->initialize());
+
+  EXPECT_TRUE(AvailableRoot->Initialized);
 
   // Check that submetrics are inserted
   const auto TV0 = firestarter::measurement::TimeValue(std::chrono::high_resolution_clock::now(), 0.0);

--- a/test/UnitTests/MetricsTest.cpp
+++ b/test/UnitTests/MetricsTest.cpp
@@ -44,7 +44,8 @@ const MetricType NoInsertCallbackMetricType{
     /*Absolute=*/0,       /*Accumalative=*/0,         /*DivideByThreadCount=*/0,
     /*InsertCallback=*/0, /*IgnoreStartStopDelta=*/0, /*Reserved=*/0};
 
-template <int32_t InitReturnValue, const MetricType& Type, uint64_t CallbackTime = 0U> struct MetricMock {
+template <int32_t InitReturnValue, const MetricType& Type, uint64_t CallbackTime = 0U, bool UseSubmetrics = false>
+struct MetricMock {
   inline static const char* FakeName = "Name";
   inline static const char* FakeUnit = "Unit";
   inline static double FakeValue = 1.0;
@@ -52,6 +53,8 @@ template <int32_t InitReturnValue, const MetricType& Type, uint64_t CallbackTime
   MOCK_METHOD(void, callbackMock, ());
 
   MOCK_METHOD(int32_t, finiMock, ());
+
+  MOCK_METHOD(const char**, getSubmetricNamesMock, ());
 
   MOCK_METHOD(int32_t, getReadingMock, (double*));
 
@@ -74,6 +77,9 @@ template <int32_t InitReturnValue, const MetricType& Type, uint64_t CallbackTime
 
   static auto instance() -> MetricMock& {
     static MetricMock Instance;
+    if constexpr (UseSubmetrics) {
+      Instance.AvailableMetric.GetSubmetricNames = getSubmetricNames;
+    }
     return Instance;
   }
 
@@ -86,6 +92,8 @@ private:
   static void callback() { return instance().callbackMock(); }
 
   static auto fini() -> int32_t { return instance().finiMock(); }
+
+  static auto getSubmetricNames() -> const char** { return instance().getSubmetricNamesMock(); };
 
   static auto getReading(double* Value) -> int32_t {
     *Value = FakeValue;
@@ -102,6 +110,7 @@ private:
 TEST(MetricsTest, CheckAvailableFromCInterface) {
   auto& AvailableMetricMock = MetricMock</*InitReturnValue=*/0, NoInsertCallbackMetricType>::instance();
   EXPECT_CALL(AvailableMetricMock, finiMock()).Times(2);
+  EXPECT_CALL(AvailableMetricMock, getSubmetricNamesMock()).Times(0);
   EXPECT_CALL(AvailableMetricMock, getReadingMock(_)).Times(0);
   EXPECT_CALL(AvailableMetricMock, registerInsertCallbackMock(_, _)).Times(0);
 
@@ -120,20 +129,27 @@ TEST(MetricsTest, CheckAvailableFromCInterface) {
 
   // Check if the metric inititializes
   EXPECT_TRUE(AvailableRoot->initialize());
+
+  EXPECT_TRUE(AvailableRoot->Submetrics.empty());
+  EXPECT_TRUE(AvailableRoot->Initialized);
 }
 
 TEST(MetricsTest, CheckUnavailableFromCInterface) {
   auto& UnavailableMetricMock = MetricMock</*InitReturnValue=*/1, NoInsertCallbackMetricType>::instance();
   EXPECT_CALL(UnavailableMetricMock, finiMock()).Times(1);
+  EXPECT_CALL(UnavailableMetricMock, getSubmetricNamesMock()).Times(0);
   EXPECT_CALL(UnavailableMetricMock, getReadingMock(_)).Times(0);
   EXPECT_CALL(UnavailableMetricMock, registerInsertCallbackMock(_, _)).Times(0);
 
   auto UnavailableRoot = firestarter::measurement::RootMetric::fromCInterface(UnavailableMetricMock.AvailableMetric);
 
   EXPECT_FALSE(UnavailableRoot->Available);
+  EXPECT_FALSE(UnavailableRoot->Initialized);
 
   // Check if the metric does not inititalize
   EXPECT_FALSE(UnavailableRoot->initialize());
+
+  EXPECT_FALSE(UnavailableRoot->Initialized);
 }
 
 TEST(MetricsTest, CheckRegisterInsertCallbackFromCInterface) {
@@ -141,6 +157,7 @@ TEST(MetricsTest, CheckRegisterInsertCallbackFromCInterface) {
   {
     auto& AvailableMetricMock = MetricMock</*InitReturnValue=*/0, InsertCallbackMetricType>::instance();
     EXPECT_CALL(AvailableMetricMock, finiMock()).Times(2);
+    EXPECT_CALL(AvailableMetricMock, getSubmetricNamesMock()).Times(0);
     EXPECT_CALL(AvailableMetricMock, getReadingMock(_)).Times(0);
 
     auto AvailableRoot = firestarter::measurement::RootMetric::fromCInterface(AvailableMetricMock.AvailableMetric);
@@ -156,6 +173,7 @@ TEST(MetricsTest, CheckRegisterInsertCallbackFromCInterface) {
   {
     auto& AvailableMetricMock = MetricMock</*InitReturnValue=*/0, NoInsertCallbackMetricType>::instance();
     EXPECT_CALL(AvailableMetricMock, finiMock()).Times(2);
+    EXPECT_CALL(AvailableMetricMock, getSubmetricNamesMock()).Times(0);
     EXPECT_CALL(AvailableMetricMock, getReadingMock(_)).Times(0);
 
     auto AvailableRoot = firestarter::measurement::RootMetric::fromCInterface(AvailableMetricMock.AvailableMetric);
@@ -174,6 +192,7 @@ TEST(MetricsTest, CheckNoTimedCallbackFromCInterface) {
   auto& AvailableMetricMock =
       MetricMock</*InitReturnValue=*/0, NoInsertCallbackMetricType, /*CallbackTime=*/0U>::instance();
   EXPECT_CALL(AvailableMetricMock, finiMock()).Times(2);
+  EXPECT_CALL(AvailableMetricMock, getSubmetricNamesMock()).Times(0);
   EXPECT_CALL(AvailableMetricMock, getReadingMock(_)).Times(0);
 
   auto AvailableRoot = firestarter::measurement::RootMetric::fromCInterface(AvailableMetricMock.AvailableMetric);
@@ -200,6 +219,7 @@ TEST(MetricsTest, CheckTimedCallbackFromCInterface) {
   auto& AvailableMetricMock =
       MetricMock</*InitReturnValue=*/0, NoInsertCallbackMetricType, /*CallbackTime=*/CallbackTime>::instance();
   EXPECT_CALL(AvailableMetricMock, finiMock()).Times(2);
+  EXPECT_CALL(AvailableMetricMock, getSubmetricNamesMock()).Times(0);
   EXPECT_CALL(AvailableMetricMock, getReadingMock(_)).Times(0);
 
   auto AvailableRoot = firestarter::measurement::RootMetric::fromCInterface(AvailableMetricMock.AvailableMetric);
@@ -244,6 +264,7 @@ TEST(MetricsTest, CheckInsertCallbackFromCInterface) {
   {
     auto& PullingMetricMock = MetricMock</*InitReturnValue=*/0, NoInsertCallbackMetricType>::instance();
     EXPECT_CALL(PullingMetricMock, finiMock()).Times(2);
+    EXPECT_CALL(PullingMetricMock, getSubmetricNamesMock()).Times(0);
 
     auto PullingRoot = firestarter::measurement::RootMetric::fromCInterface(PullingMetricMock.AvailableMetric);
 
@@ -291,6 +312,7 @@ TEST(MetricsTest, CheckInsertCallbackFromCInterface) {
   {
     auto& PushingMetricMock = MetricMock</*InitReturnValue=*/0, InsertCallbackMetricType>::instance();
     EXPECT_CALL(PushingMetricMock, finiMock()).Times(1);
+    EXPECT_CALL(PushingMetricMock, getSubmetricNamesMock()).Times(0);
     EXPECT_CALL(PushingMetricMock, getReadingMock(_)).Times(0);
     EXPECT_CALL(PushingMetricMock, registerInsertCallbackMock(_, _)).Times(0);
 
@@ -305,6 +327,7 @@ TEST(MetricsTest, CheckInsertCallbackFromCInterface) {
 TEST(MetricsTest, CheckAvailableFromStdin) {
   auto& AvailableMetricMock = MetricMock</*InitReturnValue=*/0, NoInsertCallbackMetricType>::instance();
   EXPECT_CALL(AvailableMetricMock, finiMock()).Times(0);
+  EXPECT_CALL(AvailableMetricMock, getSubmetricNamesMock()).Times(0);
   EXPECT_CALL(AvailableMetricMock, getReadingMock(_)).Times(0);
   EXPECT_CALL(AvailableMetricMock, registerInsertCallbackMock(_, _)).Times(0);
 
@@ -331,6 +354,7 @@ TEST(MetricsTest, CheckAvailableFromStdin) {
 TEST(MetricsTest, CheckNoTimedCallbackFromStdin) {
   auto& AvailableMetricMock = MetricMock</*InitReturnValue=*/0, NoInsertCallbackMetricType>::instance();
   EXPECT_CALL(AvailableMetricMock, finiMock()).Times(0);
+  EXPECT_CALL(AvailableMetricMock, getSubmetricNamesMock()).Times(0);
   EXPECT_CALL(AvailableMetricMock, getReadingMock(_)).Times(0);
 
   auto AvailableRoot =
@@ -356,6 +380,7 @@ TEST(MetricsTest, CheckNoTimedCallbackFromStdin) {
 TEST(MetricsTest, CheckNoInsertCallbackFromStdin) {
   auto& AvailableMetricMock = MetricMock</*InitReturnValue=*/0, InsertCallbackMetricType>::instance();
   EXPECT_CALL(AvailableMetricMock, finiMock()).Times(0);
+  EXPECT_CALL(AvailableMetricMock, getSubmetricNamesMock()).Times(0);
   EXPECT_CALL(AvailableMetricMock, getReadingMock(_)).Times(0);
 
   auto AvailableRoot =
@@ -377,4 +402,43 @@ TEST(MetricsTest, CheckNoInsertCallbackFromStdin) {
     auto Callback = AvailableRoot->getInsertCallback();
     EXPECT_FALSE(Callback.has_value());
   }
+}
+
+TEST(MetricsTest, CheckSubmetricsFromCInterface) {
+  using Mock =
+      MetricMock</*InitReturnValue=*/0, NoInsertCallbackMetricType, /*CallbackTime=*/0U, /*UseSubmetrics=*/true>;
+
+  std::array<const char*, 3> Submetrics = {
+      "submetric-0",
+      "submetric-1",
+      nullptr,
+  };
+
+  auto& AvailableMetricMock = Mock::instance();
+  EXPECT_CALL(AvailableMetricMock, finiMock()).Times(2);
+  EXPECT_CALL(AvailableMetricMock, getSubmetricNamesMock()).Times(1).WillOnce(Return(Submetrics.data()));
+  EXPECT_CALL(AvailableMetricMock, getReadingMock(_)).Times(0);
+  EXPECT_CALL(AvailableMetricMock, registerInsertCallbackMock(_, _)).Times(0);
+
+  auto AvailableRoot = firestarter::measurement::RootMetric::fromCInterface(AvailableMetricMock.AvailableMetric);
+
+  // Metric is created, it is not yet initialized.
+  EXPECT_EQ(AvailableRoot->Name, AvailableMetricMock.FakeName);
+  EXPECT_TRUE(AvailableRoot->Values.empty());
+  EXPECT_EQ(AvailableRoot->MetricPtr, &AvailableMetricMock.AvailableMetric);
+  EXPECT_TRUE(AvailableRoot->Submetrics.empty());
+  EXPECT_FALSE(AvailableRoot->Dylib);
+  EXPECT_FALSE(AvailableRoot->Stdin);
+  EXPECT_FALSE(AvailableRoot->Initialized);
+
+  EXPECT_TRUE(AvailableRoot->Available);
+
+  // Check if the metric inititializes
+  EXPECT_TRUE(AvailableRoot->initialize());
+
+  EXPECT_TRUE(AvailableRoot->Initialized);
+
+  EXPECT_EQ(AvailableRoot->Submetrics.size(), 2);
+  EXPECT_EQ(AvailableRoot->Submetrics[0]->Name, std::string(Submetrics[0]));
+  EXPECT_EQ(AvailableRoot->Submetrics[1]->Name, std::string(Submetrics[1]));
 }

--- a/test/UnitTests/MetricsTest.cpp
+++ b/test/UnitTests/MetricsTest.cpp
@@ -165,7 +165,7 @@ TEST(MetricsTest, CheckRegisterInsertCallbackFromCInterface) {
 
     // Check if the metric inititializes
     EXPECT_CALL(AvailableMetricMock,
-                registerInsertCallbackMock(firestarter::measurement::insertCallback, AvailableRoot.get()))
+                registerInsertCallbackMock(firestarter::measurement::RootMetric::insertCallback, AvailableRoot.get()))
         .Times(1);
 
     EXPECT_TRUE(AvailableRoot->initialize());
@@ -181,7 +181,7 @@ TEST(MetricsTest, CheckRegisterInsertCallbackFromCInterface) {
 
     // Check if the metric inititializes
     EXPECT_CALL(AvailableMetricMock,
-                registerInsertCallbackMock(firestarter::measurement::insertCallback, AvailableRoot.get()))
+                registerInsertCallbackMock(firestarter::measurement::RootMetric::insertCallback, AvailableRoot.get()))
         .Times(0);
     EXPECT_TRUE(AvailableRoot->initialize());
   }
@@ -199,7 +199,7 @@ TEST(MetricsTest, CheckNoTimedCallbackFromCInterface) {
   auto AvailableRoot = firestarter::measurement::RootMetric::fromCInterface(AvailableMetricMock.AvailableMetric);
 
   EXPECT_CALL(AvailableMetricMock,
-              registerInsertCallbackMock(firestarter::measurement::insertCallback, AvailableRoot.get()))
+              registerInsertCallbackMock(firestarter::measurement::RootMetric::insertCallback, AvailableRoot.get()))
       .Times(0);
 
   {
@@ -226,7 +226,7 @@ TEST(MetricsTest, CheckTimedCallbackFromCInterface) {
   auto AvailableRoot = firestarter::measurement::RootMetric::fromCInterface(AvailableMetricMock.AvailableMetric);
 
   EXPECT_CALL(AvailableMetricMock,
-              registerInsertCallbackMock(firestarter::measurement::insertCallback, AvailableRoot.get()))
+              registerInsertCallbackMock(firestarter::measurement::RootMetric::insertCallback, AvailableRoot.get()))
       .Times(0);
 
   {
@@ -271,7 +271,7 @@ TEST(MetricsTest, CheckInsertCallbackFromCInterface) {
 
     // Check if the metric inititializes
     EXPECT_CALL(PullingMetricMock,
-                registerInsertCallbackMock(firestarter::measurement::insertCallback, PullingRoot.get()))
+                registerInsertCallbackMock(firestarter::measurement::RootMetric::insertCallback, PullingRoot.get()))
         .Times(0);
 
     {
@@ -362,7 +362,7 @@ TEST(MetricsTest, CheckNoTimedCallbackFromStdin) {
       firestarter::measurement::RootMetric::fromStdin(MetricMock<0, NoInsertCallbackMetricType, 0>::FakeName);
 
   EXPECT_CALL(AvailableMetricMock,
-              registerInsertCallbackMock(firestarter::measurement::insertCallback, AvailableRoot.get()))
+              registerInsertCallbackMock(firestarter::measurement::RootMetric::insertCallback, AvailableRoot.get()))
       .Times(0);
 
   {
@@ -389,7 +389,7 @@ TEST(MetricsTest, CheckNoInsertCallbackFromStdin) {
 
   // Check if the metric inititializes
   EXPECT_CALL(AvailableMetricMock,
-              registerInsertCallbackMock(firestarter::measurement::insertCallback, AvailableRoot.get()))
+              registerInsertCallbackMock(firestarter::measurement::RootMetric::insertCallback, AvailableRoot.get()))
       .Times(0);
 
   {

--- a/test/UnitTests/MetricsTest.cpp
+++ b/test/UnitTests/MetricsTest.cpp
@@ -1,0 +1,155 @@
+/******************************************************************************
+ * FIRESTARTER - A Processor Stress Test Utility
+ * Copyright (C) 2024 TU Dresden, Center for Information Services and High
+ * Performance Computing
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/\>.
+ *
+ * Contact: daniel.hackenberg@tu-dresden.de
+ *****************************************************************************/
+
+#include "firestarter/Measurement/Metric.hpp"
+#include "firestarter/Measurement/MetricInterface.h"
+
+#include <cstdint>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+// NOLINTNEXTLINE(google-build-using-namespace)
+using namespace ::testing;
+
+namespace {
+
+void callback() {};
+
+template <int32_t ReturnValue> auto init() -> int32_t { return ReturnValue; };
+
+auto getReading(double* /*Value*/) -> int32_t { return 0; };
+
+auto getError() -> const char* { return ""; };
+
+const MetricType InsertCallbackMetricType{
+    /*Absolute=*/0,       /*Accumalative=*/0,         /*DivideByThreadCount=*/0,
+    /*InsertCallback=*/1, /*IgnoreStartStopDelta=*/0, /*Reserved=*/0};
+
+const MetricType NoInsertCallbackMetricType{
+    /*Absolute=*/0,       /*Accumalative=*/0,         /*DivideByThreadCount=*/0,
+    /*InsertCallback=*/0, /*IgnoreStartStopDelta=*/0, /*Reserved=*/0};
+
+template <int32_t InitReturnValue, const MetricType& Type> struct MetricMock {
+  inline static const char* Name = "Name";
+  inline static const char* Unit = "Unit";
+  inline static uint64_t CallbackTime = 0U;
+
+  MOCK_METHOD(int32_t, registerInsertCallbackMock, (void (*Ptr1)(void*, const char*, int64_t, double), void* Ptr2));
+
+  MOCK_METHOD(int32_t, finiMock, ());
+
+  MetricInterface AvailableMetric = {
+      /*Name=*/Name,
+      /*Type=*/Type,
+      /*Unit=*/Unit,
+      /*CallbackTime=*/CallbackTime,
+      /*Callback=*/callback,
+      /*Init=*/init<InitReturnValue>,
+      /*Fini=*/fini,
+      /*GetReading=*/getReading,
+      /*GetError=*/getError,
+      /*RegisterInsertCallback=*/registerInsertCallback,
+  };
+
+  static auto instance() -> MetricMock& {
+    static MetricMock Instance;
+    return Instance;
+  }
+
+  MetricMock(MetricMock const&) = delete;
+  void operator=(MetricMock const&) = delete;
+
+private:
+  MetricMock() = default;
+
+  static auto registerInsertCallback(void (*FunctionPtr)(void*, const char*, int64_t, double), void* Cls) -> int32_t {
+    return instance().registerInsertCallbackMock(FunctionPtr, Cls);
+  }
+
+  static auto fini() -> int32_t { return instance().finiMock(); }
+};
+
+}; // namespace
+
+TEST(MetricsTest, CheckAvailableMetricFromCInterface) {
+  auto& AvailableMetricMock = MetricMock</*InitReturnValue=*/0, NoInsertCallbackMetricType>::instance();
+  EXPECT_CALL(AvailableMetricMock, finiMock()).Times(2);
+  EXPECT_CALL(AvailableMetricMock, registerInsertCallbackMock(_, _)).Times(0);
+
+  auto AvailableRoot = firestarter::measurement::RootMetric::fromCInterface(AvailableMetricMock.AvailableMetric);
+
+  // Metric is created, it is not yet initialized.
+  EXPECT_EQ(AvailableRoot->Name, AvailableMetricMock.Name);
+  EXPECT_TRUE(AvailableRoot->Values.empty());
+  EXPECT_EQ(AvailableRoot->MetricPtr, &AvailableMetricMock.AvailableMetric);
+  EXPECT_TRUE(AvailableRoot->Submetrics.empty());
+  EXPECT_FALSE(AvailableRoot->Dylib);
+  EXPECT_FALSE(AvailableRoot->Stdin);
+  EXPECT_FALSE(AvailableRoot->Initialized);
+
+  EXPECT_TRUE(AvailableRoot->Available);
+
+  // Check if the metric inititializes
+  EXPECT_TRUE(AvailableRoot->initialize());
+}
+
+TEST(MetricsTest, CheckUnavailableMetricFromCInterface) {
+  auto& UnavailableMetricMock = MetricMock</*InitReturnValue=*/1, NoInsertCallbackMetricType>::instance();
+  EXPECT_CALL(UnavailableMetricMock, finiMock()).Times(1);
+  EXPECT_CALL(UnavailableMetricMock, registerInsertCallbackMock(_, _)).Times(0);
+
+  auto UnavailableRoot = firestarter::measurement::RootMetric::fromCInterface(UnavailableMetricMock.AvailableMetric);
+
+  EXPECT_FALSE(UnavailableRoot->Available);
+
+  // Check if the metric does not inititalize
+  EXPECT_FALSE(UnavailableRoot->initialize());
+}
+
+TEST(MetricsTest, CheckInsertCallback) {
+  // Check that the insert callback is provided during initialization
+  {
+    auto& AvailableMetricMock = MetricMock</*InitReturnValue=*/0, InsertCallbackMetricType>::instance();
+    EXPECT_CALL(AvailableMetricMock, finiMock()).Times(2);
+
+    auto AvailableRoot = firestarter::measurement::RootMetric::fromCInterface(AvailableMetricMock.AvailableMetric);
+
+    // Check if the metric inititializes
+    EXPECT_CALL(AvailableMetricMock,
+                registerInsertCallbackMock(firestarter::measurement::insertCallback, AvailableRoot.get()))
+        .Times(1);
+
+    EXPECT_TRUE(AvailableRoot->initialize());
+  }
+
+  {
+    auto& AvailableMetricMock = MetricMock</*InitReturnValue=*/0, NoInsertCallbackMetricType>::instance();
+    EXPECT_CALL(AvailableMetricMock, finiMock()).Times(2);
+
+    auto AvailableRoot = firestarter::measurement::RootMetric::fromCInterface(AvailableMetricMock.AvailableMetric);
+
+    // Check if the metric inititializes
+    EXPECT_CALL(AvailableMetricMock,
+                registerInsertCallbackMock(firestarter::measurement::insertCallback, AvailableRoot.get()))
+        .Times(0);
+    EXPECT_TRUE(AvailableRoot->initialize());
+  }
+}

--- a/test/UnitTests/MetricsTest.cpp
+++ b/test/UnitTests/MetricsTest.cpp
@@ -23,6 +23,7 @@
 #include "firestarter/Measurement/MetricInterface.h"
 #include "firestarter/Measurement/TimeValue.hpp"
 
+#include <array>
 #include <chrono>
 #include <cstdint>
 #include <gmock/gmock.h>


### PR DESCRIPTION
Closes #112. This PR refactors the measurement system. A C++ abstraction is implemented for the c-style metrics. A metric can expose additional submetrics. This allows for not just derived metrics, but also individual metric, e.g. rapl-package to be exposed.