### PR TITLE
Payloads: Enable selection of different control flow

### DIFF
--- a/include/firestarter/Payload/CompiledPayload.hpp
+++ b/include/firestarter/Payload/CompiledPayload.hpp
@@ -64,12 +64,12 @@ public:
   /// \arg MemoryAddr The pointer to the memory.
   /// \arg LoadVar The variable that controls the load. If this variable changes from LoadThreadWorkType::LoadHigh to
   /// something else this function will return.
-  /// \arg Iterations The current iteration counter. This number will be incremented for every iteration of the high
-  /// load loop.
-  /// \returns The iteration counter passed into this function plus the number of iteration of the high load loop.
+  /// \arg MaxNumIterations If the kernel was generated with HighLoadControlFlowDescription::kMaxIterationCount, this
+  /// variable provides the maximal number of iterations that the hot loop will run inside the kernel.
+  /// \returns The number of iteration of the high load loop.
   [[nodiscard]] auto highLoadFunction(double* MemoryAddr, volatile LoadThreadWorkType& LoadVar,
-                                      uint64_t Iterations) -> uint64_t {
-    return HighLoadFunction(MemoryAddr, &LoadVar, Iterations);
+                                      uint64_t MaxNumIterations) -> uint64_t {
+    return HighLoadFunction(MemoryAddr, &LoadVar, MaxNumIterations);
   }
 
 protected:

--- a/include/firestarter/Payload/Payload.hpp
+++ b/include/firestarter/Payload/Payload.hpp
@@ -25,6 +25,7 @@
 #include "firestarter/CpuFeatures.hpp"
 #include "firestarter/Logging/Log.hpp"
 #include "firestarter/Payload/CompiledPayload.hpp"
+#include "firestarter/Payload/PayloadControlFlowDescription.hpp"
 #include "firestarter/Payload/PayloadSettings.hpp"
 
 #include <chrono>
@@ -96,9 +97,11 @@ public:
   /// \arg ErrorDetection Should the code to support error detection between thread be baked into the high load routine
   /// of the compiled payload.
   /// \arg PrintAssembler Should the generated assembler code be logged.
+  /// \arg HighLoadControlFlowDescription Defines how the control flow of the hot loop is generated.
   /// \returns The compiled payload that provides access to the init and load functions.
-  [[nodiscard]] virtual auto compilePayload(const PayloadSettings& Settings, bool DumpRegisters, bool ErrorDetection,
-                                            bool PrintAssembler) const -> CompiledPayload::UniquePtr = 0;
+  [[nodiscard]] virtual auto
+  compilePayload(const PayloadSettings& Settings, bool DumpRegisters, bool ErrorDetection, bool PrintAssembler,
+                 HighLoadControlFlowDescription ControlFlow) const -> CompiledPayload::UniquePtr = 0;
 
   /// Get the available instruction items that are supported by this payload.
   /// \returns The available instruction items that are supported by this payload.

--- a/include/firestarter/Payload/PayloadControlFlowDescription.hpp
+++ b/include/firestarter/Payload/PayloadControlFlowDescription.hpp
@@ -1,0 +1,37 @@
+/******************************************************************************
+ * FIRESTARTER - A Processor Stress Test Utility
+ * Copyright (C) 2025 TU Dresden, Center for Information Services and High
+ * Performance Computing
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/\>.
+ *
+ * Contact: daniel.hackenberg@tu-dresden.de
+ *****************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+
+namespace firestarter::payload {
+
+/// This class describes the type of control flow that is used for the generation of the high load assembler kernels.
+enum class HighLoadControlFlowDescription : std::uint8_t {
+  // The control flow is generated such that the LoadThreadWorkType variable is used to interrupt the hot loop.
+  kStopOnLoadThreadWorkType = 0,
+  // The control flow is generated such that the LoadThreadWorkType variable is used to interrupt the hot loop. In
+  // addition the hot loop will repeat a specified maximum number of iterations.
+  kMaxIterationCount = 1
+};
+
+} // namespace firestarter::payload

--- a/include/firestarter/X86/Payload/AVX512Payload.hpp
+++ b/include/firestarter/X86/Payload/AVX512Payload.hpp
@@ -61,10 +61,12 @@ public:
   /// \arg ErrorDetection Should the code to support error detection between thread be baked into the high load routine
   /// of the compiled payload.
   /// \arg PrintAssembler Should the generated assembler code be logged.
+  /// \arg HighLoadControlFlowDescription Defines how the control flow of the hot loop is generated.
   /// \returns The compiled payload that provides access to the init and load functions.
-  [[nodiscard]] auto
-  compilePayload(const firestarter::payload::PayloadSettings& Settings, bool DumpRegisters, bool ErrorDetection,
-                 bool PrintAssembler) const -> firestarter::payload::CompiledPayload::UniquePtr override;
+  [[nodiscard]] auto compilePayload(const firestarter::payload::PayloadSettings& Settings, bool DumpRegisters,
+                                    bool ErrorDetection, bool PrintAssembler,
+                                    firestarter::payload::HighLoadControlFlowDescription ControlFlow) const
+      -> firestarter::payload::CompiledPayload::UniquePtr override;
 
 private:
   /// Function to initialize the memory used by the high load function.

--- a/include/firestarter/X86/Payload/AVXPayload.hpp
+++ b/include/firestarter/X86/Payload/AVXPayload.hpp
@@ -59,10 +59,12 @@ public:
   /// \arg ErrorDetection Should the code to support error detection between thread be baked into the high load routine
   /// of the compiled payload.
   /// \arg PrintAssembler Should the generated assembler code be logged.
+  /// \arg HighLoadControlFlowDescription Defines how the control flow of the hot loop is generated.
   /// \returns The compiled payload that provides access to the init and load functions.
-  [[nodiscard]] auto
-  compilePayload(const firestarter::payload::PayloadSettings& Settings, bool DumpRegisters, bool ErrorDetection,
-                 bool PrintAssembler) const -> firestarter::payload::CompiledPayload::UniquePtr override;
+  [[nodiscard]] auto compilePayload(const firestarter::payload::PayloadSettings& Settings, bool DumpRegisters,
+                                    bool ErrorDetection, bool PrintAssembler,
+                                    firestarter::payload::HighLoadControlFlowDescription ControlFlow) const
+      -> firestarter::payload::CompiledPayload::UniquePtr override;
 
 private:
   /// Function to initialize the memory used by the high load function.

--- a/include/firestarter/X86/Payload/FMA4Payload.hpp
+++ b/include/firestarter/X86/Payload/FMA4Payload.hpp
@@ -59,10 +59,12 @@ public:
   /// \arg ErrorDetection Should the code to support error detection between thread be baked into the high load routine
   /// of the compiled payload.
   /// \arg PrintAssembler Should the generated assembler code be logged.
+  /// \arg HighLoadControlFlowDescription Defines how the control flow of the hot loop is generated.
   /// \returns The compiled payload that provides access to the init and load functions.
-  [[nodiscard]] auto
-  compilePayload(const firestarter::payload::PayloadSettings& Settings, bool DumpRegisters, bool ErrorDetection,
-                 bool PrintAssembler) const -> firestarter::payload::CompiledPayload::UniquePtr override;
+  [[nodiscard]] auto compilePayload(const firestarter::payload::PayloadSettings& Settings, bool DumpRegisters,
+                                    bool ErrorDetection, bool PrintAssembler,
+                                    firestarter::payload::HighLoadControlFlowDescription ControlFlow) const
+      -> firestarter::payload::CompiledPayload::UniquePtr override;
 
 private:
   /// Function to initialize the memory used by the high load function.

--- a/include/firestarter/X86/Payload/FMAPayload.hpp
+++ b/include/firestarter/X86/Payload/FMAPayload.hpp
@@ -50,10 +50,12 @@ public:
   /// \arg ErrorDetection Should the code to support error detection between thread be baked into the high load routine
   /// of the compiled payload.
   /// \arg PrintAssembler Should the generated assembler code be logged.
+  /// \arg HighLoadControlFlowDescription Defines how the control flow of the hot loop is generated.
   /// \returns The compiled payload that provides access to the init and load functions.
-  [[nodiscard]] auto
-  compilePayload(const firestarter::payload::PayloadSettings& Settings, bool DumpRegisters, bool ErrorDetection,
-                 bool PrintAssembler) const -> firestarter::payload::CompiledPayload::UniquePtr override;
+  [[nodiscard]] auto compilePayload(const firestarter::payload::PayloadSettings& Settings, bool DumpRegisters,
+                                    bool ErrorDetection, bool PrintAssembler,
+                                    firestarter::payload::HighLoadControlFlowDescription ControlFlow) const
+      -> firestarter::payload::CompiledPayload::UniquePtr override;
 
 private:
   /// Function to initialize the memory used by the high load function.

--- a/include/firestarter/X86/Payload/SSE2Payload.hpp
+++ b/include/firestarter/X86/Payload/SSE2Payload.hpp
@@ -59,10 +59,12 @@ public:
   /// \arg ErrorDetection Should the code to support error detection between thread be baked into the high load routine
   /// of the compiled payload.
   /// \arg PrintAssembler Should the generated assembler code be logged.
+  /// \arg HighLoadControlFlowDescription Defines how the control flow of the hot loop is generated.
   /// \returns The compiled payload that provides access to the init and load functions.
-  [[nodiscard]] auto
-  compilePayload(const firestarter::payload::PayloadSettings& Settings, bool DumpRegisters, bool ErrorDetection,
-                 bool PrintAssembler) const -> firestarter::payload::CompiledPayload::UniquePtr override;
+  [[nodiscard]] auto compilePayload(const firestarter::payload::PayloadSettings& Settings, bool DumpRegisters,
+                                    bool ErrorDetection, bool PrintAssembler,
+                                    firestarter::payload::HighLoadControlFlowDescription ControlFlow) const
+      -> firestarter::payload::CompiledPayload::UniquePtr override;
 
 private:
   /// Function to initialize the memory used by the high load function.

--- a/include/firestarter/X86/Payload/ZENFMAPayload.hpp
+++ b/include/firestarter/X86/Payload/ZENFMAPayload.hpp
@@ -44,10 +44,12 @@ public:
   /// \arg ErrorDetection Should the code to support error detection between thread be baked into the high load routine
   /// of the compiled payload.
   /// \arg PrintAssembler Should the generated assembler code be logged.
+  /// \arg HighLoadControlFlowDescription Defines how the control flow of the hot loop is generated.
   /// \returns The compiled payload that provides access to the init and load functions.
-  [[nodiscard]] auto
-  compilePayload(const firestarter::payload::PayloadSettings& Settings, bool DumpRegisters, bool ErrorDetection,
-                 bool PrintAssembler) const -> firestarter::payload::CompiledPayload::UniquePtr override;
+  [[nodiscard]] auto compilePayload(const firestarter::payload::PayloadSettings& Settings, bool DumpRegisters,
+                                    bool ErrorDetection, bool PrintAssembler,
+                                    firestarter::payload::HighLoadControlFlowDescription ControlFlow) const
+      -> firestarter::payload::CompiledPayload::UniquePtr override;
 
 private:
   /// Function to initialize the memory used by the high load function.

--- a/src/firestarter/LoadWorker.cpp
+++ b/src/firestarter/LoadWorker.cpp
@@ -28,6 +28,7 @@
 #include "firestarter/LoadWorkerMemory.hpp"
 #include "firestarter/Logging/FirstWorkerThreadFilter.hpp"
 #include "firestarter/Logging/Log.hpp"
+#include "firestarter/Payload/PayloadControlFlowDescription.hpp"
 #include "firestarter/ThreadAffinity.hpp"
 #include "firestarter/Tracing.h"
 

--- a/src/firestarter/LoadWorker.cpp
+++ b/src/firestarter/LoadWorker.cpp
@@ -311,8 +311,9 @@ void Firestarter::loadThreadWorker(const std::shared_ptr<LoadWorkerData>& Td) {
       Td->Topology.bindCallerToOsIndex(Td->OsIndex);
 
       // compile payload
-      Td->CompiledPayloadPtr = Td->config().payload()->compilePayload(Td->config().settings(), Td->DumpRegisters,
-                                                                      Td->ErrorDetection, /*PrintAssembler=*/false);
+      Td->CompiledPayloadPtr = Td->config().payload()->compilePayload(
+          Td->config().settings(), Td->DumpRegisters, Td->ErrorDetection, /*PrintAssembler=*/false,
+          /*ControlFlow=*/firestarter::payload::HighLoadControlFlowDescription::kStopOnLoadThreadWorkType);
 
       // allocate memory
       // if we should dump some registers, we use the first part of the memory
@@ -362,8 +363,8 @@ void Firestarter::loadThreadWorker(const std::shared_ptr<LoadWorkerData>& Td) {
 #endif
 
         firestarterTracingRegionBegin("High");
-        Td->CurrentRun.Iterations = Td->CompiledPayloadPtr->highLoadFunction(Td->Memory->getMemoryAddress(),
-                                                                             Td->LoadVar, Td->CurrentRun.Iterations);
+        Td->CurrentRun.Iterations += Td->CompiledPayloadPtr->highLoadFunction(Td->Memory->getMemoryAddress(),
+                                                                              Td->LoadVar, /*MaxNumIterations=*/0);
         firestarterTracingRegionEnd("High");
 
         // call low load function
@@ -389,8 +390,9 @@ void Firestarter::loadThreadWorker(const std::shared_ptr<LoadWorkerData>& Td) {
       break;
     case LoadThreadState::ThreadSwitch:
       // compile payload
-      Td->CompiledPayloadPtr = Td->config().payload()->compilePayload(Td->config().settings(), Td->DumpRegisters,
-                                                                      Td->ErrorDetection, /*PrintAssembler=*/false);
+      Td->CompiledPayloadPtr = Td->config().payload()->compilePayload(
+          Td->config().settings(), Td->DumpRegisters, Td->ErrorDetection, /*PrintAssembler=*/false,
+          /*ControlFlow=*/firestarter::payload::HighLoadControlFlowDescription::kStopOnLoadThreadWorkType);
 
       // call init function
       Td->CompiledPayloadPtr->init(Td->Memory->getMemoryAddress(), Td->BuffersizeMem);

--- a/src/firestarter/X86/Payload/AVX512Payload.cpp
+++ b/src/firestarter/X86/Payload/AVX512Payload.cpp
@@ -116,6 +116,8 @@ auto AVX512Payload::compilePayload(const firestarter::payload::PayloadSettings& 
   const auto TempReg2 = asmjit::x86::rbp;
   const auto OffsetReg = asmjit::x86::r14;
   const auto AddrHighReg = asmjit::x86::r15;
+  // Since we exhausted the x86 general purpose registers, we need to rely on additional mmx register. They shall only
+  // be used for less frequent accesses and not as an intergral part of the hot loop.
   // This register contains the current number of loop iterations
   const auto IterReg = asmjit::x86::mm0;
   // This register holds the remaining number of iterations, if the payload is compiled with

--- a/src/firestarter/X86/Payload/AVX512Payload.cpp
+++ b/src/firestarter/X86/Payload/AVX512Payload.cpp
@@ -36,8 +36,11 @@
 namespace firestarter::x86::payload {
 
 auto AVX512Payload::compilePayload(const firestarter::payload::PayloadSettings& Settings, bool DumpRegisters,
-                                   bool ErrorDetection,
-                                   bool PrintAssembler) const -> firestarter::payload::CompiledPayload::UniquePtr {
+                                   bool ErrorDetection, bool PrintAssembler,
+                                   firestarter::payload::HighLoadControlFlowDescription ControlFlow) const
+    -> firestarter::payload::CompiledPayload::UniquePtr {
+  (void)ControlFlow;
+
   using Imm = asmjit::Imm;
   using Zmm = asmjit::x86::Zmm;
   // NOLINTBEGIN(readability-identifier-naming)

--- a/src/firestarter/X86/Payload/AVX512Payload.cpp
+++ b/src/firestarter/X86/Payload/AVX512Payload.cpp
@@ -23,6 +23,7 @@
 #include "firestarter/Constants.hpp"
 #include "firestarter/Logging/Log.hpp"
 #include "firestarter/Payload/CompiledPayload.hpp"
+#include "firestarter/Payload/PayloadControlFlowDescription.hpp"
 #include "firestarter/Payload/PayloadSettings.hpp"
 #include "firestarter/Payload/PayloadStats.hpp"
 #include "firestarter/X86/Payload/CompiledX86Payload.hpp"
@@ -39,8 +40,6 @@ auto AVX512Payload::compilePayload(const firestarter::payload::PayloadSettings& 
                                    bool ErrorDetection, bool PrintAssembler,
                                    firestarter::payload::HighLoadControlFlowDescription ControlFlow) const
     -> firestarter::payload::CompiledPayload::UniquePtr {
-  (void)ControlFlow;
-
   using Imm = asmjit::Imm;
   using Zmm = asmjit::x86::Zmm;
   // NOLINTBEGIN(readability-identifier-naming)
@@ -117,7 +116,11 @@ auto AVX512Payload::compilePayload(const firestarter::payload::PayloadSettings& 
   const auto TempReg2 = asmjit::x86::rbp;
   const auto OffsetReg = asmjit::x86::r14;
   const auto AddrHighReg = asmjit::x86::r15;
+  // This register contains the current number of loop iterations
   const auto IterReg = asmjit::x86::mm0;
+  // This register holds the remaining number of iterations, if the payload is compiled with
+  // HighLoadControlFlowDescription::kMaxIterationCount
+  const auto RemainingIterationsReg = asmjit::x86::mm1;
   const auto ShiftReg = std::vector<asmjit::x86::Gp>({asmjit::x86::rdi, asmjit::x86::rsi, asmjit::x86::rdx});
   const auto ShiftReg32 = std::vector<asmjit::x86::Gp>({asmjit::x86::edi, asmjit::x86::esi, asmjit::x86::edx});
   const auto NrShiftRegs = 3;
@@ -143,7 +146,7 @@ auto AVX512Payload::compilePayload(const firestarter::payload::PayloadSettings& 
   }
   // make all other used registers dirty except RAX
   Frame.addDirtyRegs(L1Addr, L2Addr, L3Addr, RamAddr, L2CountReg, L3CountReg, RamCountReg, TempReg, TempReg2, OffsetReg,
-                     AddrHighReg, IterReg, RamAddr);
+                     AddrHighReg, IterReg, RemainingIterationsReg);
   for (const auto& Reg : ShiftReg) {
     Frame.addDirtyRegs(Reg);
   }
@@ -157,12 +160,22 @@ auto AVX512Payload::compilePayload(const firestarter::payload::PayloadSettings& 
   Cb.emitProlog(Frame);
   Cb.emitArgsAssignment(Frame, Args);
 
-  // FIXME: movq from temp_reg to iter_reg
+  auto FunctionExit = Cb.newLabel();
+
+  if (ControlFlow == firestarter::payload::HighLoadControlFlowDescription::kMaxIterationCount) {
+    // save iteration count
+    Cb.movq(RemainingIterationsReg, TempReg);
+
+    // return if zero
+    Cb.test(TempReg, TempReg);
+    Cb.jz(FunctionExit);
+  }
+
+  // Set inital iteration count to zero
+  Cb.mov(TempReg, Imm(0));
   Cb.movq(IterReg, TempReg);
 
   // stop right away if low load is selected
-  auto FunctionExit = Cb.newLabel();
-
   Cb.mov(TempReg, ptr_64(AddrHighReg));
   Cb.test(TempReg, TempReg);
   Cb.jz(FunctionExit);
@@ -326,7 +339,12 @@ auto AVX512Payload::compilePayload(const firestarter::payload::PayloadSettings& 
     }
   }
 
-  Cb.movq(TempReg, IterReg); // restore iteration counter
+  // restore iteration counter
+  Cb.movq(TempReg, IterReg);
+  // restore remaining iterations
+  if (ControlFlow == firestarter::payload::HighLoadControlFlowDescription::kMaxIterationCount) {
+    Cb.movq(TempReg2, RemainingIterationsReg);
+  }
   if (firestarter::payload::PayloadSettings::getRAMSequenceCount(Sequence) > 0) {
     // reset RAM counter
     auto NoRamReset = Cb.newLabel();
@@ -340,7 +358,16 @@ auto AVX512Payload::compilePayload(const firestarter::payload::PayloadSettings& 
     // adds always two instruction
     Stats.Instructions += 2;
   }
-  Cb.inc(TempReg); // increment iteration counter
+  // increment iteration counter
+  Cb.inc(TempReg);
+  if (ControlFlow == firestarter::payload::HighLoadControlFlowDescription::kMaxIterationCount) {
+    // decrement remaining iterations
+    Cb.dec(TempReg2);
+
+    // Return if the remaining instructions reached zero
+    Cb.test(TempReg2, TempReg2);
+    Cb.jz(FunctionExit);
+  }
   if (firestarter::payload::PayloadSettings::getL2SequenceCount(Sequence) > 0) {
     // reset L2-Cache counter
     auto NoL2Reset = Cb.newLabel();
@@ -354,7 +381,12 @@ auto AVX512Payload::compilePayload(const firestarter::payload::PayloadSettings& 
     // adds always two instruction
     Stats.Instructions += 2;
   }
-  Cb.movq(IterReg, TempReg); // store iteration counter
+  // store iteration counter
+  Cb.movq(IterReg, TempReg);
+  // store remaining iterations
+  if (ControlFlow == firestarter::payload::HighLoadControlFlowDescription::kMaxIterationCount) {
+    Cb.movq(RemainingIterationsReg, TempReg2);
+  }
   if (firestarter::payload::PayloadSettings::getL3SequenceCount(Sequence) > 0) {
     // reset L3-Cache counter
     auto NoL3Reset = Cb.newLabel();

--- a/src/firestarter/X86/Payload/AVXPayload.cpp
+++ b/src/firestarter/X86/Payload/AVXPayload.cpp
@@ -23,6 +23,7 @@
 #include "firestarter/Constants.hpp"
 #include "firestarter/Logging/Log.hpp"
 #include "firestarter/Payload/CompiledPayload.hpp"
+#include "firestarter/Payload/PayloadControlFlowDescription.hpp"
 #include "firestarter/Payload/PayloadSettings.hpp"
 #include "firestarter/Payload/PayloadStats.hpp"
 #include "firestarter/X86/Payload/CompiledX86Payload.hpp"

--- a/src/firestarter/X86/Payload/AVXPayload.cpp
+++ b/src/firestarter/X86/Payload/AVXPayload.cpp
@@ -36,8 +36,11 @@
 namespace firestarter::x86::payload {
 
 auto AVXPayload::compilePayload(const firestarter::payload::PayloadSettings& Settings, bool DumpRegisters,
-                                bool ErrorDetection,
-                                bool PrintAssembler) const -> firestarter::payload::CompiledPayload::UniquePtr {
+                                bool ErrorDetection, bool PrintAssembler,
+                                firestarter::payload::HighLoadControlFlowDescription ControlFlow) const
+    -> firestarter::payload::CompiledPayload::UniquePtr {
+  (void)ControlFlow;
+
   using Imm = asmjit::Imm;
   using Mm = asmjit::x86::Mm;
   using Xmm = asmjit::x86::Xmm;

--- a/src/firestarter/X86/Payload/AVXPayload.cpp
+++ b/src/firestarter/X86/Payload/AVXPayload.cpp
@@ -39,8 +39,6 @@ auto AVXPayload::compilePayload(const firestarter::payload::PayloadSettings& Set
                                 bool ErrorDetection, bool PrintAssembler,
                                 firestarter::payload::HighLoadControlFlowDescription ControlFlow) const
     -> firestarter::payload::CompiledPayload::UniquePtr {
-  (void)ControlFlow;
-
   using Imm = asmjit::Imm;
   using Mm = asmjit::x86::Mm;
   using Xmm = asmjit::x86::Xmm;
@@ -115,7 +113,11 @@ auto AVXPayload::compilePayload(const firestarter::payload::PayloadSettings& Set
   const auto TempReg2 = asmjit::x86::rbp;
   const auto OffsetReg = asmjit::x86::r12;
   const auto AddrHighReg = asmjit::x86::r13;
+  // This register contains the current number of loop iterations
   const auto IterReg = asmjit::x86::r14;
+  // This register holds the remaining number of iterations, if the payload is compiled with
+  // HighLoadControlFlowDescription::kMaxIterationCount
+  const auto RemainingIterationsReg = asmjit::x86::r15;
   const auto ShiftRegs = 6;
   const auto AddRegs = 10;
   const auto TransRegs = 6;
@@ -138,10 +140,10 @@ auto AVXPayload::compilePayload(const firestarter::payload::PayloadSettings& Set
   }
   // make all other used registers dirty except RAX
   Frame.addDirtyRegs(L1Addr, L2Addr, L3Addr, RamAddr, L2CountReg, L3CountReg, RamCountReg, TempReg, TempReg2, OffsetReg,
-                     AddrHighReg, IterReg);
+                     AddrHighReg, IterReg, RemainingIterationsReg);
 
   asmjit::FuncArgsAssignment Args(&Func);
-  Args.assignAll(PointerReg, AddrHighReg, IterReg);
+  Args.assignAll(PointerReg, AddrHighReg, RemainingIterationsReg);
   Args.updateFuncFrame(Frame);
   Frame.finalize();
 
@@ -151,6 +153,16 @@ auto AVXPayload::compilePayload(const firestarter::payload::PayloadSettings& Set
   // stop right away if low load is selected
   auto FunctionExit = Cb.newLabel();
 
+  // Set inital iteration count to zero
+  Cb.mov(IterReg, Imm(0));
+
+  if (ControlFlow == firestarter::payload::HighLoadControlFlowDescription::kMaxIterationCount) {
+    // return if remaining iteration count is zero
+    Cb.test(RemainingIterationsReg, RemainingIterationsReg);
+    Cb.jz(FunctionExit);
+  }
+
+  // stop right away if low load is selected
   Cb.mov(TempReg, ptr_64(AddrHighReg));
   Cb.test(TempReg, TempReg);
   Cb.jz(FunctionExit);
@@ -388,7 +400,17 @@ auto AVXPayload::compilePayload(const firestarter::payload::PayloadSettings& Set
     // adds always two instruction
     Stats.Instructions += 2;
   }
-  Cb.inc(IterReg); // increment iteration counter
+
+  // increment iteration counter
+  Cb.inc(IterReg);
+  if (ControlFlow == firestarter::payload::HighLoadControlFlowDescription::kMaxIterationCount) {
+    // decrement remaining iterations
+    Cb.dec(RemainingIterationsReg);
+    // Return if the remaining instructions reached zero
+    Cb.test(RemainingIterationsReg, RemainingIterationsReg);
+    Cb.jz(FunctionExit);
+  }
+
   Cb.mov(L1Addr, PointerReg);
 
   if (DumpRegisters) {

--- a/src/firestarter/X86/Payload/FMA4Payload.cpp
+++ b/src/firestarter/X86/Payload/FMA4Payload.cpp
@@ -23,6 +23,7 @@
 #include "firestarter/Constants.hpp"
 #include "firestarter/Logging/Log.hpp"
 #include "firestarter/Payload/CompiledPayload.hpp"
+#include "firestarter/Payload/PayloadControlFlowDescription.hpp"
 #include "firestarter/Payload/PayloadSettings.hpp"
 #include "firestarter/Payload/PayloadStats.hpp"
 #include "firestarter/X86/Payload/CompiledX86Payload.hpp"

--- a/src/firestarter/X86/Payload/FMA4Payload.cpp
+++ b/src/firestarter/X86/Payload/FMA4Payload.cpp
@@ -115,6 +115,8 @@ auto FMA4Payload::compilePayload(const firestarter::payload::PayloadSettings& Se
   const auto TempReg2 = asmjit::x86::rbp;
   const auto OffsetReg = asmjit::x86::r14;
   const auto AddrHighReg = asmjit::x86::r15;
+  // Since we exhausted the x86 general purpose registers, we need to rely on additional mmx register. They shall only
+  // be used for less frequent accesses and not as an intergral part of the hot loop.
   // This register contains the current number of loop iterations
   const auto IterReg = asmjit::x86::mm0;
   // This register holds the remaining number of iterations, if the payload is compiled with

--- a/src/firestarter/X86/Payload/FMA4Payload.cpp
+++ b/src/firestarter/X86/Payload/FMA4Payload.cpp
@@ -36,8 +36,11 @@
 namespace firestarter::x86::payload {
 
 auto FMA4Payload::compilePayload(const firestarter::payload::PayloadSettings& Settings, bool DumpRegisters,
-                                 bool ErrorDetection,
-                                 bool PrintAssembler) const -> firestarter::payload::CompiledPayload::UniquePtr {
+                                 bool ErrorDetection, bool PrintAssembler,
+                                 firestarter::payload::HighLoadControlFlowDescription ControlFlow) const
+    -> firestarter::payload::CompiledPayload::UniquePtr {
+  (void)ControlFlow;
+
   using Imm = asmjit::Imm;
   using Xmm = asmjit::x86::Xmm;
   // NOLINTBEGIN(readability-identifier-naming)

--- a/src/firestarter/X86/Payload/FMAPayload.cpp
+++ b/src/firestarter/X86/Payload/FMAPayload.cpp
@@ -23,6 +23,7 @@
 #include "firestarter/Constants.hpp"
 #include "firestarter/Logging/Log.hpp"
 #include "firestarter/Payload/CompiledPayload.hpp"
+#include "firestarter/Payload/PayloadControlFlowDescription.hpp"
 #include "firestarter/Payload/PayloadSettings.hpp"
 #include "firestarter/Payload/PayloadStats.hpp"
 #include "firestarter/X86/Payload/CompiledX86Payload.hpp"

--- a/src/firestarter/X86/Payload/FMAPayload.cpp
+++ b/src/firestarter/X86/Payload/FMAPayload.cpp
@@ -39,8 +39,6 @@ auto FMAPayload::compilePayload(const firestarter::payload::PayloadSettings& Set
                                 bool ErrorDetection, bool PrintAssembler,
                                 firestarter::payload::HighLoadControlFlowDescription ControlFlow) const
     -> firestarter::payload::CompiledPayload::UniquePtr {
-  (void)ControlFlow;
-
   using Imm = asmjit::Imm;
   using Xmm = asmjit::x86::Xmm;
   using Ymm = asmjit::x86::Ymm;
@@ -118,7 +116,11 @@ auto FMAPayload::compilePayload(const firestarter::payload::PayloadSettings& Set
   const auto TempReg2 = asmjit::x86::rbp;
   const auto OffsetReg = asmjit::x86::r14;
   const auto AddrHighReg = asmjit::x86::r15;
+  // This register contains the current number of loop iterations
   const auto IterReg = asmjit::x86::mm0;
+  // This register holds the remaining number of iterations, if the payload is compiled with
+  // HighLoadControlFlowDescription::kMaxIterationCount
+  const auto RemainingIterationsReg = asmjit::x86::mm1;
   const auto ShiftRegs = std::vector<asmjit::x86::Gp>({asmjit::x86::rdi, asmjit::x86::rsi, asmjit::x86::rdx});
   const auto ShiftRegs32 = std::vector<asmjit::x86::Gp>({asmjit::x86::edi, asmjit::x86::esi, asmjit::x86::edx});
   const auto NbShiftRegs = 3;
@@ -144,7 +146,7 @@ auto FMAPayload::compilePayload(const firestarter::payload::PayloadSettings& Set
   }
   // make all other used registers dirty except RAX
   Frame.addDirtyRegs(L1Addr, L2Addr, L3Addr, RamAddr, L2CountReg, L3CountReg, RamCountReg, TempReg, TempReg2, OffsetReg,
-                     AddrHighReg, IterReg, RamAddr);
+                     AddrHighReg, IterReg, RemainingIterationsReg);
   for (const auto& Reg : ShiftRegs) {
     Frame.addDirtyRegs(Reg);
   }
@@ -158,12 +160,22 @@ auto FMAPayload::compilePayload(const firestarter::payload::PayloadSettings& Set
   Cb.emitProlog(Frame);
   Cb.emitArgsAssignment(Frame, Args);
 
-  // FIXME: movq from temp_reg to iter_reg
+  auto FunctionExit = Cb.newLabel();
+
+  if (ControlFlow == firestarter::payload::HighLoadControlFlowDescription::kMaxIterationCount) {
+    // save iteration count
+    Cb.movq(RemainingIterationsReg, TempReg);
+
+    // return if zero
+    Cb.test(TempReg, TempReg);
+    Cb.jz(FunctionExit);
+  }
+
+  // Set inital iteration count to zero
+  Cb.mov(TempReg, Imm(0));
   Cb.movq(IterReg, TempReg);
 
   // stop right away if low load is selected
-  auto FunctionExit = Cb.newLabel();
-
   Cb.mov(TempReg, ptr_64(AddrHighReg));
   Cb.test(TempReg, TempReg);
   Cb.jz(FunctionExit);
@@ -355,7 +367,12 @@ auto FMAPayload::compilePayload(const firestarter::payload::PayloadSettings& Set
     }
   }
 
-  Cb.movq(TempReg, IterReg); // restore iteration counter
+  // restore iteration counter
+  Cb.movq(TempReg, IterReg);
+  // restore remaining iterations
+  if (ControlFlow == firestarter::payload::HighLoadControlFlowDescription::kMaxIterationCount) {
+    Cb.movq(TempReg2, RemainingIterationsReg);
+  }
   if (firestarter::payload::PayloadSettings::getRAMSequenceCount(Sequence) > 0) {
     // reset RAM counter
     auto NoRamReset = Cb.newLabel();
@@ -369,7 +386,16 @@ auto FMAPayload::compilePayload(const firestarter::payload::PayloadSettings& Set
     // adds always two instruction
     Stats.Instructions += 2;
   }
-  Cb.inc(TempReg); // increment iteration counter
+  // increment iteration counter
+  Cb.inc(TempReg);
+  if (ControlFlow == firestarter::payload::HighLoadControlFlowDescription::kMaxIterationCount) {
+    // decrement remaining iterations
+    Cb.dec(TempReg2);
+
+    // Return if the remaining instructions reached zero
+    Cb.test(TempReg2, TempReg2);
+    Cb.jz(FunctionExit);
+  }
   if (firestarter::payload::PayloadSettings::getL2SequenceCount(Sequence) > 0) {
     // reset L2-Cache counter
     auto NoL2Reset = Cb.newLabel();
@@ -383,7 +409,12 @@ auto FMAPayload::compilePayload(const firestarter::payload::PayloadSettings& Set
     // adds always two instruction
     Stats.Instructions += 2;
   }
-  Cb.movq(IterReg, TempReg); // store iteration counter
+  // store iteration counter
+  Cb.movq(IterReg, TempReg);
+  // store remaining iterations
+  if (ControlFlow == firestarter::payload::HighLoadControlFlowDescription::kMaxIterationCount) {
+    Cb.movq(RemainingIterationsReg, TempReg2);
+  }
   if (firestarter::payload::PayloadSettings::getL3SequenceCount(Sequence) > 0) {
     // reset L3-Cache counter
     auto NoL3Reset = Cb.newLabel();

--- a/src/firestarter/X86/Payload/FMAPayload.cpp
+++ b/src/firestarter/X86/Payload/FMAPayload.cpp
@@ -36,8 +36,11 @@
 namespace firestarter::x86::payload {
 
 auto FMAPayload::compilePayload(const firestarter::payload::PayloadSettings& Settings, bool DumpRegisters,
-                                bool ErrorDetection,
-                                bool PrintAssembler) const -> firestarter::payload::CompiledPayload::UniquePtr {
+                                bool ErrorDetection, bool PrintAssembler,
+                                firestarter::payload::HighLoadControlFlowDescription ControlFlow) const
+    -> firestarter::payload::CompiledPayload::UniquePtr {
+  (void)ControlFlow;
+
   using Imm = asmjit::Imm;
   using Xmm = asmjit::x86::Xmm;
   using Ymm = asmjit::x86::Ymm;

--- a/src/firestarter/X86/Payload/FMAPayload.cpp
+++ b/src/firestarter/X86/Payload/FMAPayload.cpp
@@ -117,6 +117,8 @@ auto FMAPayload::compilePayload(const firestarter::payload::PayloadSettings& Set
   const auto TempReg2 = asmjit::x86::rbp;
   const auto OffsetReg = asmjit::x86::r14;
   const auto AddrHighReg = asmjit::x86::r15;
+  // Since we exhausted the x86 general purpose registers, we need to rely on additional mmx register. They shall only
+  // be used for less frequent accesses and not as an intergral part of the hot loop.
   // This register contains the current number of loop iterations
   const auto IterReg = asmjit::x86::mm0;
   // This register holds the remaining number of iterations, if the payload is compiled with

--- a/src/firestarter/X86/Payload/SSE2Payload.cpp
+++ b/src/firestarter/X86/Payload/SSE2Payload.cpp
@@ -23,6 +23,7 @@
 #include "firestarter/Constants.hpp"
 #include "firestarter/Logging/Log.hpp"
 #include "firestarter/Payload/CompiledPayload.hpp"
+#include "firestarter/Payload/PayloadControlFlowDescription.hpp"
 #include "firestarter/Payload/PayloadSettings.hpp"
 #include "firestarter/Payload/PayloadStats.hpp"
 #include "firestarter/X86/Payload/CompiledX86Payload.hpp"

--- a/src/firestarter/X86/Payload/SSE2Payload.cpp
+++ b/src/firestarter/X86/Payload/SSE2Payload.cpp
@@ -39,8 +39,6 @@ auto SSE2Payload::compilePayload(const firestarter::payload::PayloadSettings& Se
                                  bool ErrorDetection, bool PrintAssembler,
                                  firestarter::payload::HighLoadControlFlowDescription ControlFlow) const
     -> firestarter::payload::CompiledPayload::UniquePtr {
-  (void)ControlFlow;
-
   using Imm = asmjit::Imm;
   using Mm = asmjit::x86::Mm;
   using Xmm = asmjit::x86::Xmm;
@@ -114,7 +112,11 @@ auto SSE2Payload::compilePayload(const firestarter::payload::PayloadSettings& Se
   const auto TempReg2 = asmjit::x86::rbp;
   const auto OffsetReg = asmjit::x86::r12;
   const auto AddrHighReg = asmjit::x86::r13;
+  // This register contains the current number of loop iterations
   const auto IterReg = asmjit::x86::r14;
+  // This register holds the remaining number of iterations, if the payload is compiled with
+  // HighLoadControlFlowDescription::kMaxIterationCount
+  const auto RemainingIterationsReg = asmjit::x86::r15;
   constexpr const auto MovRegs = 0;
   const auto AddRegs = 14;
   const auto TransRegs = 2;
@@ -137,10 +139,10 @@ auto SSE2Payload::compilePayload(const firestarter::payload::PayloadSettings& Se
   }
   // make all other used registers dirty except RAX
   Frame.addDirtyRegs(L1Addr, L2Addr, L3Addr, RamAddr, L2CountReg, L3CountReg, RamCountReg, TempReg, TempReg2, OffsetReg,
-                     AddrHighReg, IterReg);
+                     AddrHighReg, IterReg, RemainingIterationsReg);
 
   asmjit::FuncArgsAssignment Args(&Func);
-  Args.assignAll(PointerReg, AddrHighReg, IterReg);
+  Args.assignAll(PointerReg, AddrHighReg, RemainingIterationsReg);
   Args.updateFuncFrame(Frame);
   Frame.finalize();
 
@@ -150,6 +152,16 @@ auto SSE2Payload::compilePayload(const firestarter::payload::PayloadSettings& Se
   // stop right away if low load is selected
   auto FunctionExit = Cb.newLabel();
 
+  // Set inital iteration count to zero
+  Cb.mov(IterReg, Imm(0));
+
+  if (ControlFlow == firestarter::payload::HighLoadControlFlowDescription::kMaxIterationCount) {
+    // return if remaining iteration count is zero
+    Cb.test(RemainingIterationsReg, RemainingIterationsReg);
+    Cb.jz(FunctionExit);
+  }
+
+  // stop right away if low load is selected
   Cb.mov(TempReg, ptr_64(AddrHighReg));
   Cb.test(TempReg, TempReg);
   Cb.jz(FunctionExit);
@@ -379,7 +391,17 @@ auto SSE2Payload::compilePayload(const firestarter::payload::PayloadSettings& Se
     // adds always two instruction
     Stats.Instructions += 2;
   }
-  Cb.inc(IterReg); // increment iteration counter
+
+  // increment iteration counter
+  Cb.inc(IterReg);
+  if (ControlFlow == firestarter::payload::HighLoadControlFlowDescription::kMaxIterationCount) {
+    // decrement remaining iterations
+    Cb.dec(RemainingIterationsReg);
+    // Return if the remaining instructions reached zero
+    Cb.test(RemainingIterationsReg, RemainingIterationsReg);
+    Cb.jz(FunctionExit);
+  }
+
   Cb.mov(L1Addr, PointerReg);
 
   if (DumpRegisters) {

--- a/src/firestarter/X86/Payload/SSE2Payload.cpp
+++ b/src/firestarter/X86/Payload/SSE2Payload.cpp
@@ -36,8 +36,11 @@
 namespace firestarter::x86::payload {
 
 auto SSE2Payload::compilePayload(const firestarter::payload::PayloadSettings& Settings, bool DumpRegisters,
-                                 bool ErrorDetection,
-                                 bool PrintAssembler) const -> firestarter::payload::CompiledPayload::UniquePtr {
+                                 bool ErrorDetection, bool PrintAssembler,
+                                 firestarter::payload::HighLoadControlFlowDescription ControlFlow) const
+    -> firestarter::payload::CompiledPayload::UniquePtr {
+  (void)ControlFlow;
+
   using Imm = asmjit::Imm;
   using Mm = asmjit::x86::Mm;
   using Xmm = asmjit::x86::Xmm;

--- a/src/firestarter/X86/Payload/ZENFMAPayload.cpp
+++ b/src/firestarter/X86/Payload/ZENFMAPayload.cpp
@@ -36,8 +36,11 @@
 namespace firestarter::x86::payload {
 
 auto ZENFMAPayload::compilePayload(const firestarter::payload::PayloadSettings& Settings, bool DumpRegisters,
-                                   bool ErrorDetection,
-                                   bool PrintAssembler) const -> firestarter::payload::CompiledPayload::UniquePtr {
+                                   bool ErrorDetection, bool PrintAssembler,
+                                   firestarter::payload::HighLoadControlFlowDescription ControlFlow) const
+    -> firestarter::payload::CompiledPayload::UniquePtr {
+  (void)ControlFlow;
+
   using Imm = asmjit::Imm;
   using Xmm = asmjit::x86::Xmm;
   using Ymm = asmjit::x86::Ymm;

--- a/src/firestarter/X86/Payload/ZENFMAPayload.cpp
+++ b/src/firestarter/X86/Payload/ZENFMAPayload.cpp
@@ -23,6 +23,7 @@
 #include "firestarter/Constants.hpp"
 #include "firestarter/Logging/Log.hpp"
 #include "firestarter/Payload/CompiledPayload.hpp"
+#include "firestarter/Payload/PayloadControlFlowDescription.hpp"
 #include "firestarter/Payload/PayloadSettings.hpp"
 #include "firestarter/Payload/PayloadStats.hpp"
 #include "firestarter/X86/Payload/CompiledX86Payload.hpp"

--- a/src/firestarter/X86/Payload/ZENFMAPayload.cpp
+++ b/src/firestarter/X86/Payload/ZENFMAPayload.cpp
@@ -113,6 +113,8 @@ auto ZENFMAPayload::compilePayload(const firestarter::payload::PayloadSettings& 
   auto TempReg2 = asmjit::x86::rbp;
   auto OffsetReg = asmjit::x86::r14;
   auto AddrHighReg = asmjit::x86::r15;
+  // Since we exhausted the x86 general purpose registers, we need to rely on additional mmx register. They shall only
+  // be used for less frequent accesses and not as an intergral part of the hot loop.
   // This register contains the current number of loop iterations
   auto IterReg = asmjit::x86::mm0;
   // This register holds the remaining number of iterations, if the payload is compiled with

--- a/test/DumpPayloads/Main.cpp
+++ b/test/DumpPayloads/Main.cpp
@@ -50,7 +50,8 @@ void dumpPayload(firestarter::payload::Payload& PayloadPtr) {
                                                  /*Groups=*/oneEach(Instuctions));
 
   (void)PayloadPtr.compilePayload(Settings, /*DumpRegisters=*/false, /*ErrorDetection=*/false,
-                                  /*PrintAssembler=*/true);
+                                  /*PrintAssembler=*/true,
+                                  firestarter::payload::HighLoadControlFlowDescription::kStopOnLoadThreadWorkType);
 }
 
 } // namespace

--- a/test/UnitTests/FunctionSelectionTest.cpp
+++ b/test/UnitTests/FunctionSelectionTest.cpp
@@ -53,7 +53,8 @@ public:
   [[nodiscard]] auto compilePayload(const firestarter::payload::PayloadSettings& /*Settings*/,
                                     bool
                                     /*DumpRegisters*/,
-                                    bool /*ErrorDetection*/, bool /*PrintAssembler*/) const
+                                    bool /*ErrorDetection*/, bool /*PrintAssembler*/,
+                                    firestarter::payload::HighLoadControlFlowDescription /*ControlFlow*/) const
       -> firestarter::payload::CompiledPayload::UniquePtr override {
     return {nullptr, nullptr};
   }
@@ -82,7 +83,7 @@ public:
             /*Payload=*/std::make_shared<FakePayload<PayloadIsAvailable>>())
       , Id(Id) {}
 
-  [[nodiscard]] auto getId() const -> auto{ return Id; }
+  [[nodiscard]] auto getId() const -> auto { return Id; }
 
 private:
   [[nodiscard]] auto isDefault(const firestarter::CpuModel& /*Model*/,
@@ -92,8 +93,8 @@ private:
 
   [[nodiscard]] auto clone() const -> std::unique_ptr<PlatformConfig> override { return nullptr; }
 
-  [[nodiscard]] auto cloneConcreate(std::optional<unsigned> InstructionCacheSize, unsigned ThreadsPerCore) const
-      -> std::unique_ptr<PlatformConfig> override {
+  [[nodiscard]] auto cloneConcreate(std::optional<unsigned> InstructionCacheSize,
+                                    unsigned ThreadsPerCore) const -> std::unique_ptr<PlatformConfig> override {
     auto Config = std::make_unique<FakePlatfromConfig<PayloadIsAvailable, IsDefault>>(Id);
     Config->settings().concretize(InstructionCacheSize, ThreadsPerCore);
     return Config;
@@ -139,8 +140,8 @@ public:
         FakeCpuModel(), FakeCpuFeatures(), "VendorString", "ModelString", InstructionCacheSize, NumThreadsPerCore);
   }
 
-  [[nodiscard]] auto platformConfigs() const
-      -> const std::vector<std::shared_ptr<firestarter::platform::PlatformConfig>>& override {
+  [[nodiscard]] auto
+  platformConfigs() const -> const std::vector<std::shared_ptr<firestarter::platform::PlatformConfig>>& override {
     return PlatformConfigs;
   }
 

--- a/test/UnitTests/X86PayloadTest.cpp
+++ b/test/UnitTests/X86PayloadTest.cpp
@@ -22,6 +22,7 @@
 #include "firestarter/X86/Payload/X86Payload.hpp"
 
 #include <asmjit/asmjit.h>
+#include <firestarter/Payload/PayloadControlFlowDescription.hpp>
 #include <gtest/gtest.h>
 
 namespace {
@@ -42,7 +43,8 @@ public:
   void init(double* /*MemoryAddr*/, uint64_t /*BufferSize*/) const override {}
 
   [[nodiscard]] auto compilePayload(const firestarter::payload::PayloadSettings& /*Settings*/, bool /*DumpRegisters*/,
-                                    bool /*ErrorDetection*/, bool /*PrintAssembler*/) const
+                                    bool /*ErrorDetection*/, bool /*PrintAssembler*/,
+                                    firestarter::payload::HighLoadControlFlowDescription /*ControlFlow*/) const
       -> firestarter::payload::CompiledPayload::UniquePtr override {
     return {nullptr, nullptr};
   }

--- a/test/UnitTests/X86PlatformConfigTest.cpp
+++ b/test/UnitTests/X86PlatformConfigTest.cpp
@@ -40,7 +40,8 @@ public:
   void init(double* /*MemoryAddr*/, uint64_t /*BufferSize*/) const override {}
 
   [[nodiscard]] auto compilePayload(const firestarter::payload::PayloadSettings& /*Settings*/, bool /*DumpRegisters*/,
-                                    bool /*ErrorDetection*/, bool /*PrintAssembler*/) const
+                                    bool /*ErrorDetection*/, bool /*PrintAssembler*/,
+                                    firestarter::payload::HighLoadControlFlowDescription /*ControlFlow*/) const
       -> firestarter::payload::CompiledPayload::UniquePtr override {
     return {nullptr, nullptr};
   }

--- a/test/refs/DumpPayloads.log
+++ b/test/refs/DumpPayloads.log
@@ -9,6 +9,7 @@ push r15
 mov rax, rdi
 mov r15, rsi
 mov r13, rdx
+mov r13, 0
 movq mm0, r13
 mov r13, qword ptr [r15]
 test r13, r13
@@ -362,6 +363,7 @@ push r15
 mov rax, rdi
 mov r15, rsi
 mov r13, rdx
+mov r13, 0
 movq mm0, r13
 mov r13, qword ptr [r15]
 test r13, r13
@@ -757,6 +759,7 @@ push r15
 mov rax, rdi
 mov r15, rsi
 mov r13, rdx
+mov r13, 0
 movq mm0, r13
 mov r13, qword ptr [r15]
 test r13, r13
@@ -910,6 +913,7 @@ push r15
 mov rax, rdi
 mov r15, rsi
 mov r13, rdx
+mov r13, 0
 movq mm0, r13
 mov r13, qword ptr [r15]
 test r13, r13
@@ -1210,9 +1214,11 @@ push rbp
 push r12
 push r13
 push r14
+push r15
 mov rax, rdi
 mov r13, rsi
-mov r14, rdx
+mov r15, rdx
+mov r14, 0
 mov r11, qword ptr [r13]
 test r11, r11
 jz L0
@@ -1504,6 +1510,7 @@ test qword ptr [r13], 1
 jnz L1
 L0:
 mov rax, r14
+pop r15
 pop r14
 pop r13
 pop r12
@@ -1518,9 +1525,11 @@ push rbp
 push r12
 push r13
 push r14
+push r15
 mov rax, rdi
 mov r13, rsi
-mov r14, rdx
+mov r15, rdx
+mov r14, 0
 mov r11, qword ptr [r13]
 test r11, r11
 jz L0
@@ -1746,6 +1755,7 @@ test qword ptr [r13], 1
 jnz L1
 L0:
 mov rax, r14
+pop r15
 pop r14
 pop r13
 pop r12


### PR DESCRIPTION
This PR adds the option to select different control flow in the high load assembler kernels.
A kernel can either be compiled to emit:
1. the standard behaviours, where the hot loop is stopped via a shared memory location and
2. additionally the option to specify a maximum number of loop iterations after which the loop is exited
This feature is required for the integration of firestarter inside roco2, see https://github.com/tud-zih-energy/roco2/pull/11